### PR TITLE
Add runtime separation, tooling, and peephole optimization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,7 @@ seme> :quit
 - `docs/language-guide.md`: 開発原則と適用範囲の入口
 - `docs/spec-mvp-local.md`: 実装判断の規範仕様
 - `docs/implementation-playbook.md`: フェーズ別実装手順と受け入れ条件
+- `docs/bytecode-vm-plan.md`: bytecode/VM 実行トラックへの移行計画
 - `docs/branching.md`: ブランチ運用ルール
 - `docs/branching-quick-ref.md`: ブランチ運用クイックリファレンス
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ python3 -m pip install -e .
 seme check hello.seme
 seme run hello.seme
 seme repl
+seme debug bytecode hello.seme
 ```
 
 インストールせずに試したい場合は、`src` を `PYTHONPATH` に追加して
@@ -27,6 +28,7 @@ Python から直接 CLI モジュールを起動する。
 PYTHONPATH=src python3 -m seme.cli check hello.seme
 PYTHONPATH=src python3 -m seme.cli run hello.seme
 PYTHONPATH=src python3 -m seme.cli repl
+PYTHONPATH=src python3 -m seme.cli debug bytecode hello.seme
 ```
 
 `hello.seme` の例:
@@ -131,12 +133,40 @@ seme> print(x);
 seme> :quit
 ```
 
+## Debug Example
+
+`debug bytecode` は、ソースを bytecode にコンパイルして、人が読める listing を表示する。
+`run` と違って実行はしないので、VM に渡す前の命令列を確認したいときに使う。
+
+```bash
+seme debug bytecode docs/examples/hello.seme
+```
+
+出力の例:
+
+```text
+0000 LOAD_CONST 0 (1) ; 1:1
+0001 PRINT ; 1:1
+0002 RETURN ; 1:1
+```
+
+用途としては次のあたりが向いている。
+
+- compiler が期待どおりの opcode を出しているか確認する
+- jump や scope cleanup の位置を見比べる
+- validator や disassembler の挙動を手元で確認する
+
+`debug bytecode` も通常の `run` / `check` と同じく、parse や typecheck に失敗した場合は
+stderr に診断を出して終了する。
+
 ## Documents
 
 - `docs/language-guide.md`: 開発原則と適用範囲の入口
 - `docs/spec-mvp-local.md`: 実装判断の規範仕様
 - `docs/implementation-playbook.md`: フェーズ別実装手順と受け入れ条件
 - `docs/bytecode-vm-plan.md`: bytecode/VM 実行トラックへの移行計画
+- `docs/runtime-tooling-roadmap.md`: runtime tooling と observability の追跡計画
+- `docs/runtime-objects.md`: heap-managed runtime object の設計メモ
 - `docs/branching.md`: ブランチ運用ルール
 - `docs/branching-quick-ref.md`: ブランチ運用クイックリファレンス
 

--- a/docs/bytecode-vm-plan.md
+++ b/docs/bytecode-vm-plan.md
@@ -79,11 +79,13 @@ MVP で必要な opcode は次の通り。
 chunk は次の 3 要素を持つ。
 
 - `instructions`: opcode と operand 列
-- `constants`: `int | bool | string` を格納する定数プール
+- `constants`: `SemeInt | SemeBool | SemeString` を格納する定数プール
 - `source_map`: 各 instruction offset に対応する `line` / `column`
 
 この形により compiler と VM は同じ実行単位を共有でき、runtime fault 発生時も
 instruction pointer から元ソース位置を逆引きできる。
+
+runtime value の詳細方針は `docs/runtime-values.md` を参照する。
 
 ## 5. Milestones
 

--- a/docs/bytecode-vm-plan.md
+++ b/docs/bytecode-vm-plan.md
@@ -1,0 +1,217 @@
+# seme Bytecode/VM Execution Plan
+
+この文書は Issue `#17` の実装計画であり、`seme` を AST 直接実行から
+bytecode compile + VM run へ段階的に拡張するための方針を定義する。
+
+## 1. Goals
+
+- 現行パイプライン `lex -> parse -> type-check -> eval` に対し、
+  `lex -> parse -> type-check -> compile -> vm-run` を追加する
+- AST インタプリタは VM が機能同等になるまで参照実装として残す
+- CLI 利用者の挙動を大きく崩さず、段階的に切り替え可能にする
+
+## 2. Non-Goals
+
+- JIT や最適化パスの導入
+- 仕様外機能の追加
+- MVP の型システムや構文の変更
+
+## 3. Current Baseline
+
+現状の `seme` は次の構成になっている。
+
+- `src/seme/pipeline.py`: `run_check`, `run_execute` が AST interpreter を呼ぶ
+- `src/seme/interpreter.py`: AST を直接評価する参照実装
+- `tests/unit/test_interpreter.py`, `tests/unit/test_run_pipeline.py`,
+  `tests/cli/test_run_cli.py`: 実行系の回帰テスト
+
+bytecode 化では、型検査済み AST を入力として compiler が chunk を生成し、
+VM が chunk を実行する。
+
+## 4. Target Architecture
+
+### 4.1 Execution Modes
+
+- `interpreter`: 既存の AST evaluator
+- `vm`: 新しい bytecode compiler + VM runtime
+
+内部 API では execution mode を切り替え可能にして、
+CLI の `run` は既定で `vm` を使う。`interpreter` は parity 比較と
+移行中の参照実装として維持する。
+
+### 4.2 Proposed Modules
+
+- `src/seme/bytecode.py`: opcode, instruction, chunk, constant pool
+- `src/seme/compiler.py`: AST -> bytecode 変換
+- `src/seme/vm.py`: stack-based virtual machine
+- `src/seme/pipeline.py`: compile/vm-run 統合と mode 切り替え
+
+## 4.3 Initial Instruction Set
+
+MVP で必要な opcode は次の通り。
+
+| Opcode | Operands | Purpose |
+| --- | --- | --- |
+| `LOAD_CONST` | `const_index` | 定数プールから値を積む |
+| `LOAD_UNINITIALIZED` | なし | 未初期化 local 用 sentinel を積む |
+| `LOAD_LOCAL` | `slot` | local slot の値を積む |
+| `STORE_LOCAL` | `slot` | local slot に値を書き戻す |
+| `POP` | なし | スタックトップを捨てる |
+| `POP_N` | `count` | block exit 時などに複数値を捨てる |
+| `ADD` `SUB` `MUL` `DIV` `MOD` | なし | 整数演算 |
+| `NEGATE` | なし | 単項 `-` |
+| `NOT` | なし | 論理否定 |
+| `EQUAL` `NOT_EQUAL` | なし | 同型比較 |
+| `LESS` `LESS_EQUAL` `GREATER` `GREATER_EQUAL` | なし | 整数比較 |
+| `JUMP` | `target_offset` | 無条件分岐 |
+| `JUMP_IF_FALSE` | `target_offset` | 条件 false 時分岐 |
+| `PRINT` | なし | 値を 1 行出力 |
+| `RETURN` | なし | chunk 実行終了 |
+
+補足:
+
+- local 変数は compiler が slot 番号へ解決する
+- `&&` と `||` は short-circuit を保つため jump 命令の組み合わせで表現する
+- scope 終了時の local cleanup は `POP_N` で表現する
+
+## 4.4 Chunk Format
+
+chunk は次の 3 要素を持つ。
+
+- `instructions`: opcode と operand 列
+- `constants`: `int | bool | string` を格納する定数プール
+- `source_map`: 各 instruction offset に対応する `line` / `column`
+
+この形により compiler と VM は同じ実行単位を共有でき、runtime fault 発生時も
+instruction pointer から元ソース位置を逆引きできる。
+
+## 5. Milestones
+
+### 5.1 Issue `#18`: Instruction set and chunk format
+
+- 命令セットを最小 MVP 構文に合わせて定義する
+- 定数テーブル、命令列、ソース位置の保持方法を決める
+- 診断やデバッグに必要な逆引き情報を持たせる
+
+完了条件:
+
+- int / bool / string の定数ロードを表現できる
+- 変数 load/store、算術、比較、分岐、jump、print、return を表現できる
+- 命令とソース位置の対応がテスト可能
+
+### 5.2 Issue `#19`: Compiler scaffolding and labels
+
+- compiler state, scope metadata, symbol slots を導入する
+- 前方 jump のための label / patching utility を実装する
+- 変数解決を VM 用 slot 番号へ写像できるようにする
+
+完了条件:
+
+- block/scope ごとのローカル変数数を追跡できる
+- 未解決 jump を後から patch できる
+- compiler 単体で chunk 生成の骨格がテスト可能
+
+### 5.3 Issue `#20`: Expressions and basic statements
+
+- literal, unary, binary, grouping, identifier を compile する
+- `let`, `const`, assignment, expr stmt, `print` を compile する
+- 型検査済み AST を前提に、VM 実行可能な chunk を生成する
+
+完了条件:
+
+- 直線的なプログラムが VM で実行できる
+- 算術・比較・論理演算の結果が interpreter と一致する
+
+### 5.4 Issue `#21`: Control-flow and blocks
+
+- `if`, `while`, `for`, block を compile する
+- block exit 時の slot cleanup を明示する
+- loop back-edge と conditional jump を扱えるようにする
+
+完了条件:
+
+- 制御構文を含むサンプルが VM で実行できる
+- スコープ境界をまたぐ変数解決が interpreter と一致する
+
+### 5.5 Issue `#22`: Stack-based VM runtime
+
+- operand stack, call-free frame model, locals storage を実装する
+- opcode dispatch と runtime diagnostics を実装する
+- `RUNTIME-001` の表現を既存 CLI 契約へ合わせる
+
+完了条件:
+
+- compiler が出した chunk を最後まで実行できる
+- 実行時エラー時に位置付き診断を返せる
+
+### 5.6 Issue `#23`: Pipeline and CLI integration
+
+- `pipeline.py` に compile/vm-run 経路を追加する
+- interpreter と vm の切替点を内部 API に導入する
+- 必要であれば CLI に実験用 mode 切替を追加する
+
+完了条件:
+
+- `check` は従来どおり type-check まで
+- `run` は mode に応じて interpreter または vm を使える
+- 既存 CLI 契約を壊さない
+
+### 5.7 Issue `#24`: Parity and focused tests
+
+- bytecode chunk 単体テストを追加する
+- VM 命令実行テストを追加する
+- interpreter / vm parity テストを追加する
+
+完了条件:
+
+- 同じソースで interpreter と vm の stdout / diagnostics が一致する
+- 主要 opcode と制御構文に回帰テストがある
+
+## 6. Design Constraints
+
+### 6.1 Type checker stays before compilation
+
+compiler は型検査済み AST を前提とし、型規則の再検証は行わない。
+これにより compiler/VM は runtime semantics に集中できる。
+
+### 6.2 Source locations are first-class
+
+既存 CLI は位置付き診断を前提にしているため、bytecode 命令から元ソース位置を
+追跡できなければならない。各 instruction offset に line/column を結び付ける。
+
+### 6.3 AST interpreter remains the oracle
+
+移行中の正しさ判定は既存 interpreter を基準にする。
+VM 実装中に仕様解釈が揺れた場合は `docs/spec-mvp-local.md` を優先し、
+必要に応じて interpreter 側も揃えて修正する。
+
+## 7. Testing Strategy
+
+- unit:
+  `bytecode.py`, `compiler.py`, `vm.py` の局所テスト
+- integration:
+  `pipeline.py` 経由で compile/vm-run を検証
+- parity:
+  同一ソースを interpreter と vm の両方で実行し、stdout/diagnostics を比較
+
+優先ケース:
+
+- 直線的な算術と代入
+- `if/else`, `while`, `for`
+- block shadowing
+- `const` 再代入や不正 runtime の診断位置
+
+## 8. Rollout Plan
+
+1. bytecode 形式と compiler 基盤を追加する
+2. 式と単純文を VM で動かす
+3. 制御構文を VM へ拡張する
+4. pipeline に mode 切替を入れる
+5. parity テストで interpreter と比較する
+6. 既定実行系を VM に切り替える
+
+## 9. Exit Criteria for Closing Issue `#17`
+
+- 本計画がリポジトリに追加されている
+- 後続 Issue `#18` から `#24` の責務分割が明文化されている
+- AST interpreter を残した段階的移行方針が明記されている

--- a/docs/runtime-objects.md
+++ b/docs/runtime-objects.md
@@ -1,0 +1,137 @@
+# seme Runtime Objects
+
+この文書は Issue `#36` の設計メモであり、`seme` runtime における
+heap-managed object の最小モデルを定義する。
+
+## Goal
+
+- 現在の immediate value (`SemeInt`, `SemeBool`, `SemeString`) と将来の
+  heap object を明示的に区別できるようにする
+- object identity と ownership の責務を runtime 側へ集約する
+- `#35` の allocation helper と `#33` の GC hook 準備にそのまま使える
+  土台を決める
+
+## Non-Goals
+
+- この段階で GC を実装すること
+- すぐに全ての runtime value を heap object 化すること
+- MVP 仕様にない compound value や user-defined function を導入すること
+
+## Current Baseline
+
+現状の runtime value は次の immediate value のみである。
+
+- `SemeInt`
+- `SemeBool`
+- `SemeString`
+- sentinel: `UNINITIALIZED`, `VOID`
+
+これらは immutable で、Python object の寿命に実装上は乗っている。
+一方で runtime 自身は heap ownership をまだ明示していない。
+
+## Proposed Model
+
+### 1. Value Split
+
+runtime 上の値は次の 2 層に分ける。
+
+- immediate value:
+  `SemeInt`, `SemeBool` のように軽量でコピー可能な値
+- heap object handle:
+  runtime が所有する heap object を参照する値
+
+当面は `int` と `bool` を immediate のまま維持し、
+将来の拡張性を優先して `string` を最初の heap-managed 候補とする。
+
+理由:
+
+- 文字列は長さ可変で、将来 intern / concat / slice などの拡張点になりやすい
+- `int` / `bool` は immediate のままの方が MVP 実装を保ちやすい
+- object identity を導入する最初の対象として扱いやすい
+
+### 2. Object Shape
+
+heap object は runtime 所有の record として管理する。
+
+最小構造:
+
+- `object_id`: runtime 内で一意な識別子
+- `kind`: object kind (`string` から開始)
+- `payload`: kind ごとの実データ
+- `marked` または同等の GC 用 flag を将来追加可能な形にする
+
+公開 API からは Python の生オブジェクトではなく、
+runtime value としての handle 経由で参照する。
+
+### 3. Ownership Rules
+
+object の生存は runtime が管理し、次の root から到達可能であることを前提にする。
+
+- VM operand stack
+- active frame locals
+- global storage
+- constant pool
+- builtin 呼び出し中の一時引数
+
+この root set は `#33` の GC hook でそのまま列挙対象になる。
+
+### 4. Equality and Formatting
+
+- immediate value 同士の equality は現行ルールを維持する
+- heap object 同士は、kind ごとの value equality を基本にする
+- object identity は runtime 内部では保持するが、
+  MVP の言語仕様としては identity 比較演算子はまだ導入しない
+- `print` や diagnostic 表示は object kind ごとの formatter に委譲する
+
+つまり language surface では「文字列として等しいか」を維持しつつ、
+runtime 内部では object identity を持てるようにする。
+
+### 5. API Direction
+
+`#35` で追加したい API の方向性は次のとおり。
+
+- `allocate_string(value: str) -> RuntimeValue`
+- `is_heap_object(value: RuntimeValue) -> bool`
+- `object_kind(value: RuntimeValue) -> str | None`
+- `format_runtime_value(value: RuntimeValue) -> str`
+- `runtime_equal(...)` は heap object を含んでも backend 共通で動く
+- execution state は `gc_root_values()` のような hook で root 値を列挙できる
+- `RuntimeHeap.live_object_ids(...)` のような helper で後段の GC が参照集合を作れる
+
+重要なのは allocation を runtime module / allocator API の背後に隠し、
+他 module に ownership 詳細を漏らさないこと。
+
+## Initial Rollout
+
+導入順は次のとおり。
+
+1. object handle 型と runtime-owned object table を定義する
+2. string を object allocation API 経由で生成可能にする
+3. formatting / equality helper を heap object 対応にする
+4. root set 列挙 hook を追加する
+5. compound value や closure はその後に載せる
+
+## Design Constraints
+
+- backend 間で object 表現は共有する
+- compiler / VM / interpreter から Python の生 `str` を直接所有しない
+- constant pool に heap object を置く場合も、ownership は chunk ではなく
+  runtime が把握できる形に寄せる
+- immediate value と object handle を混在させても `RUNTIME-001` の契約は崩さない
+
+## Open Questions
+
+- string literal を compile 時に object 化するか、runtime 開始時に materialize するか
+- string interning を最初から入れるか、後段に回すか
+- object handle を整数 id にするか、専用 dataclass にするか
+- constant pool ownership を chunk と runtime のどちらが持つか
+
+現時点では、専用 handle dataclass を使い、literal materialization は runtime 開始時に
+寄せる案が保守しやすい。
+
+## Exit Criteria
+
+- heap-managed にする最初の対象が明確である
+- stack value と heap object の責務分離が明確である
+- formatting / equality / ownership の扱いが実装可能な粒度で整理されている
+- `#35` と `#33` の前提が文書化されている

--- a/docs/runtime-tooling-roadmap.md
+++ b/docs/runtime-tooling-roadmap.md
@@ -1,0 +1,116 @@
+# seme Runtime Tooling and Observability Roadmap
+
+この文書は Issue `#42` の追跡メモであり、`seme` runtime の安全性・観測性・
+ツール群を別トラックとして整理する。
+
+## Goal
+
+- bytecode 実行の安全性と可観測性を runtime 機能として強化する
+- validation / tracing / inspection / profiling / serialization を
+  それぞれ独立した子 issue に分ける
+- language surface の変更と runtime tooling を混線させない
+
+## Non-Goals
+
+- この段階で最適化や JIT を導入すること
+- 言語仕様や AST/bytecode 命令セットを増やすこと
+- 既存の `run` / `check` の契約を壊すこと
+
+## Current Baseline
+
+現状の runtime には次の要素がある。
+
+- `src/seme/bytecode.py`: opcode, instruction, chunk, source map
+- `src/seme/compiler.py`: AST から bytecode への変換
+- `src/seme/vm.py`: stack-based execution と runtime diagnostics
+- `src/seme/pipeline.py`: `vm` / `interpreter` の切り替え
+- `src/seme/cli.py`: `run`, `check`, `repl`
+
+また、`docs/bytecode-vm-plan.md` で VM 実行本体の作業はほぼ整理済みであり、
+`#42` はその上に載る tooling を対象とする。
+
+## Workstreams
+
+### 1. Bytecode Safety
+
+- bytecode chunk の validator を追加する
+- validator を compile/run のどこで呼ぶかを決める
+- invalid chunk を早期に失敗させる
+
+### 2. Inspection Tools
+
+- bytecode disassembler を追加する
+- CLI から chunk を閲覧する debug entry point を追加する
+- source map を見やすく表示できるようにする
+
+### 3. Runtime Tracing
+
+- VM execution trace hooks を追加する
+- opcode step, stack effect, source location を観測可能にする
+- tracing は通常実行の stdout/stderr 契約と分離する
+
+### 4. Persistence and Cache
+
+- bytecode serialization / deserialization を追加する
+- build cache の層を検討する
+- cache invalidation の単位を source / chunk / version で整理する
+
+### 5. Profiling and Metrics
+
+- runtime execution metrics を収集できるようにする
+- profiling hooks を追加する
+- 収集データの公開範囲を限定する
+- `VMMetrics` のような集約型 summary を返せるようにする
+- wall-clock duration, instruction count, peak depths, opcode counts を扱う
+
+### 6. Diagnostics and Source Mapping
+
+- source mapping の精度を runtime diagnostics に合わせて強化する
+- validator / tracer / profiler が同じ source map を参照できるようにする
+- future tooling にも流用できる共通表示を作る
+- source location resolution の shared helper を導入する
+- broken chunk や incomplete map でも安全な fallback を定義する
+
+### 7. Optimization Primitives
+
+- peephole optimization を bytecode レベルで導入する
+- 現状は literal folding と dead stack churn の削減を行う post-pass として実装済み
+- 最適化は tooling の安全性と分離して進める
+
+## Child Issues
+
+- Add a bytecode validator for seme chunks
+- Integrate bytecode validation into compile/run execution flow
+- Add a bytecode disassembler for seme
+- Add VM execution tracing hooks
+- Add CLI/debug entry points for bytecode inspection
+- Add bytecode serialization and deserialization support
+- Add a bytecode cache layer for seme builds
+- Add runtime execution metrics and profiling hooks
+- Add peephole optimization support for seme bytecode (implemented)
+- Strengthen source mapping for bytecode/runtime diagnostics
+- Add tests for validation, tracing, serialization, and tooling
+
+## Suggested Order
+
+1. validator
+2. source map strengthening
+3. disassembler and debug entry points
+4. tracing hooks
+5. serialization / cache
+6. profiling / metrics
+7. peephole optimization
+8. tests for the above
+
+## Testing Strategy
+
+- unit: validator, disassembler, serializer, tracer
+- integration: CLI debug entry points and compile/run validation flow
+- parity: ensure observability features do not change execution stdout/stderr
+
+## Exit Criteria
+
+- runtime tooling work is split into focused issues
+- validation and observability are scoped separately from language semantics
+- source mapping and diagnostics are clearly shared across tools
+- there is a clear path from bytecode inspection to runtime metrics

--- a/docs/runtime-values.md
+++ b/docs/runtime-values.md
@@ -41,3 +41,4 @@ runtime value の最小方針を残す。
 
 - 文字列演算や将来の runtime value 種別を追加する場合もこの module を拡張点にする
 - 必要なら今後、runtime helper API と fault 方針をさらに docs に昇格させる
+- heap-managed object の設計方針は `docs/runtime-objects.md` を参照する

--- a/docs/runtime-values.md
+++ b/docs/runtime-values.md
@@ -1,0 +1,43 @@
+# seme Runtime Values
+
+このメモは Issue `#31` の軽量な設計メモであり、`seme` 実行系が共有する
+runtime value の最小方針を残す。
+
+## Goal
+
+- VM と AST interpreter が Python 組み込み値ではなく `seme` 所有の値表現を使う
+- 値の表示、型判定、演算可否判定を共有 helper に集約する
+- 未初期化値や statement-only な非値を sentinel で明示する
+
+## Current Model
+
+- `SemeInt`
+- `SemeBool`
+- `SemeString`
+- `UNINITIALIZED`
+- `VOID`
+
+`RuntimeValue = SemeInt | SemeBool | SemeString` とし、
+実行スタックや束縛には sentinel を含む `StackValue` を使う。
+
+## Design Notes
+
+- 値オブジェクトは immutable な dataclass とする
+- `bool` と `int` の Python 上の継承関係に引きずられないよう、
+  `SemeBool` と `SemeInt` は明示的に分離する
+- bytecode constant pool にも runtime value をそのまま格納する
+- `print` 表示は helper 経由で行い、`true` / `false` 表記を backend 間で一致させる
+- runtime helper は型不一致やゼロ除算を backend 共通メッセージで報告できるようにする
+- helper API は少なくとも「生成」「型判定」「safe conversion」「formatting」を公開する
+
+## Backend Contract
+
+- compiler は literal を runtime value に変換して constant pool へ入れる
+- VM は stack/local 上で `StackValue` を扱う
+- interpreter も束縛と式評価で同じ value/sentinel を使う
+- backend ごとの責務は source location を付けて `RUNTIME-001` に変換するところまで
+
+## Near-term Follow-up
+
+- 文字列演算や将来の runtime value 種別を追加する場合もこの module を拡張点にする
+- 必要なら今後、runtime helper API と fault 方針をさらに docs に昇格させる

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ seme = "seme.cli:main"
 [project.optional-dependencies]
 dev = ["pytest>=8.0.0"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/seme"]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]

--- a/src/seme/builtins.py
+++ b/src/seme/builtins.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+from seme.runtime import RuntimeHeap, RuntimeValue, RuntimeValueError, StackValue, VOID, format_runtime_value
+
+
+class RuntimeHost(Protocol):
+    @property
+    def runtime_heap(self) -> RuntimeHeap:
+        ...
+
+    def write_stdout_line(self, line: str) -> None:
+        ...
+
+
+BuiltinHandler = Callable[[list[RuntimeValue], RuntimeHost], StackValue]
+
+
+@dataclass(frozen=True)
+class BuiltinSpec:
+    name: str
+    arity: int
+    handler: BuiltinHandler
+
+
+class BuiltinRegistry:
+    def __init__(self, builtins: list[BuiltinSpec] | None = None) -> None:
+        self._builtins: dict[str, BuiltinSpec] = {}
+        for builtin in builtins or []:
+            self.register(builtin)
+
+    def register(self, builtin: BuiltinSpec) -> None:
+        self._builtins[builtin.name] = builtin
+
+    def lookup(self, name: str) -> BuiltinSpec | None:
+        return self._builtins.get(name)
+
+    def invoke(self, name: str, args: list[RuntimeValue], host: RuntimeHost) -> StackValue:
+        builtin = self.lookup(name)
+        if builtin is None:
+            raise RuntimeValueError(f"unknown builtin '{name}'")
+        if len(args) != builtin.arity:
+            if builtin.arity == 1:
+                raise RuntimeValueError(f"{name} requires exactly one argument")
+            raise RuntimeValueError(f"{name} requires exactly {builtin.arity} arguments")
+        return builtin.handler(args, host)
+
+
+def _print_builtin(args: list[RuntimeValue], host: RuntimeHost) -> StackValue:
+    host.write_stdout_line(format_runtime_value(args[0], heap=host.runtime_heap))
+    return VOID
+
+
+DEFAULT_BUILTINS = BuiltinRegistry(
+    builtins=[
+        BuiltinSpec(name="print", arity=1, handler=_print_builtin),
+    ]
+)
+
+
+__all__ = [
+    "BuiltinRegistry",
+    "BuiltinSpec",
+    "DEFAULT_BUILTINS",
+    "RuntimeHost",
+]

--- a/src/seme/bytecode.py
+++ b/src/seme/bytecode.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+ConstantValue = int | bool | str
+
+
+class OpCode(StrEnum):
+    LOAD_CONST = "LOAD_CONST"
+    LOAD_UNINITIALIZED = "LOAD_UNINITIALIZED"
+    LOAD_LOCAL = "LOAD_LOCAL"
+    STORE_LOCAL = "STORE_LOCAL"
+    POP = "POP"
+    POP_N = "POP_N"
+    ADD = "ADD"
+    SUB = "SUB"
+    MUL = "MUL"
+    DIV = "DIV"
+    MOD = "MOD"
+    NEGATE = "NEGATE"
+    NOT = "NOT"
+    EQUAL = "EQUAL"
+    NOT_EQUAL = "NOT_EQUAL"
+    LESS = "LESS"
+    LESS_EQUAL = "LESS_EQUAL"
+    GREATER = "GREATER"
+    GREATER_EQUAL = "GREATER_EQUAL"
+    JUMP = "JUMP"
+    JUMP_IF_FALSE = "JUMP_IF_FALSE"
+    PRINT = "PRINT"
+    RETURN = "RETURN"
+
+
+@dataclass(frozen=True)
+class SourceSpan:
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class Instruction:
+    opcode: OpCode
+    operands: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class LocalInfo:
+    name: str
+    slot: int
+    depth: int
+    is_const: bool
+
+
+@dataclass
+class Chunk:
+    instructions: list[Instruction] = field(default_factory=list)
+    constants: list[ConstantValue] = field(default_factory=list)
+    source_map: list[SourceSpan] = field(default_factory=list)
+
+    def add_constant(self, value: ConstantValue) -> int:
+        self.constants.append(value)
+        return len(self.constants) - 1
+
+    def emit(self, opcode: OpCode, *operands: int, span: SourceSpan) -> int:
+        self.instructions.append(Instruction(opcode=opcode, operands=operands))
+        self.source_map.append(span)
+        return len(self.instructions) - 1
+
+    def span_for_offset(self, offset: int) -> SourceSpan:
+        return self.source_map[offset]
+
+
+BYTECODE_INSTRUCTION_SET: dict[OpCode, str] = {
+    OpCode.LOAD_CONST: "Push a constant-pool value onto the operand stack.",
+    OpCode.LOAD_UNINITIALIZED: "Push an uninitialized local sentinel onto the operand stack.",
+    OpCode.LOAD_LOCAL: "Push a local slot value onto the operand stack.",
+    OpCode.STORE_LOCAL: "Write the top of stack into a local slot without popping it.",
+    OpCode.POP: "Discard the top stack value.",
+    OpCode.POP_N: "Discard N locals from the end of the local-slots array.",
+    OpCode.ADD: "Pop two ints and push their sum.",
+    OpCode.SUB: "Pop two ints and push their difference.",
+    OpCode.MUL: "Pop two ints and push their product.",
+    OpCode.DIV: "Pop two ints and push their quotient.",
+    OpCode.MOD: "Pop two ints and push their modulo.",
+    OpCode.NEGATE: "Pop one int and push its negation.",
+    OpCode.NOT: "Pop one bool and push its logical negation.",
+    OpCode.EQUAL: "Pop two same-typed values and push equality result.",
+    OpCode.NOT_EQUAL: "Pop two same-typed values and push inequality result.",
+    OpCode.LESS: "Pop two ints and push left < right.",
+    OpCode.LESS_EQUAL: "Pop two ints and push left <= right.",
+    OpCode.GREATER: "Pop two ints and push left > right.",
+    OpCode.GREATER_EQUAL: "Pop two ints and push left >= right.",
+    OpCode.JUMP: "Set the instruction pointer to an absolute target offset.",
+    OpCode.JUMP_IF_FALSE: "Peek one bool and jump when the value is false.",
+    OpCode.PRINT: "Pop one runtime value and append its display form to stdout.",
+    OpCode.RETURN: "Terminate chunk execution.",
+}
+
+
+__all__ = [
+    "BYTECODE_INSTRUCTION_SET",
+    "Chunk",
+    "ConstantValue",
+    "Instruction",
+    "LocalInfo",
+    "OpCode",
+    "SourceSpan",
+]

--- a/src/seme/bytecode.py
+++ b/src/seme/bytecode.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
-ConstantValue = int | bool | str
+from seme.runtime import RuntimeValue
+
+ConstantValue = RuntimeValue
 
 
 class OpCode(StrEnum):

--- a/src/seme/bytecode.py
+++ b/src/seme/bytecode.py
@@ -11,6 +11,9 @@ ConstantValue = RuntimeValue
 class OpCode(StrEnum):
     LOAD_CONST = "LOAD_CONST"
     LOAD_UNINITIALIZED = "LOAD_UNINITIALIZED"
+    LOAD_GLOBAL = "LOAD_GLOBAL"
+    DEFINE_GLOBAL = "DEFINE_GLOBAL"
+    STORE_GLOBAL = "STORE_GLOBAL"
     LOAD_LOCAL = "LOAD_LOCAL"
     STORE_LOCAL = "STORE_LOCAL"
     POP = "POP"
@@ -54,6 +57,12 @@ class LocalInfo:
     is_const: bool
 
 
+@dataclass(frozen=True)
+class GlobalInfo:
+    name: str
+    is_const: bool
+
+
 @dataclass
 class Chunk:
     instructions: list[Instruction] = field(default_factory=list)
@@ -76,6 +85,9 @@ class Chunk:
 BYTECODE_INSTRUCTION_SET: dict[OpCode, str] = {
     OpCode.LOAD_CONST: "Push a constant-pool value onto the operand stack.",
     OpCode.LOAD_UNINITIALIZED: "Push an uninitialized local sentinel onto the operand stack.",
+    OpCode.LOAD_GLOBAL: "Push a global value onto the operand stack by name.",
+    OpCode.DEFINE_GLOBAL: "Define or initialize a global binding from the top of stack.",
+    OpCode.STORE_GLOBAL: "Assign the top of stack into an existing global binding.",
     OpCode.LOAD_LOCAL: "Push a local slot value onto the operand stack.",
     OpCode.STORE_LOCAL: "Write the top of stack into a local slot without popping it.",
     OpCode.POP: "Discard the top stack value.",
@@ -104,6 +116,7 @@ __all__ = [
     "BYTECODE_INSTRUCTION_SET",
     "Chunk",
     "ConstantValue",
+    "GlobalInfo",
     "Instruction",
     "LocalInfo",
     "OpCode",

--- a/src/seme/bytecode_cache.py
+++ b/src/seme/bytecode_cache.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from seme.bytecode import Chunk
+from seme.bytecode_serialization import deserialize_chunk, serialize_chunk
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    source_hash: str
+    compiler_version: str
+
+
+@dataclass
+class BytecodeCache:
+    entries: dict[CacheKey, str] = field(default_factory=dict)
+
+    def get_or_build(
+        self,
+        *,
+        source_hash: str,
+        compiler_version: str,
+        build: Callable[[], Chunk],
+    ) -> Chunk:
+        key = CacheKey(source_hash=source_hash, compiler_version=compiler_version)
+        serialized = self.entries.get(key)
+        if serialized is not None:
+            return deserialize_chunk(serialized)
+        chunk = build()
+        self.entries[key] = serialize_chunk(chunk)
+        return chunk
+
+    def clear(self) -> None:
+        self.entries.clear()
+
+
+__all__ = [
+    "BytecodeCache",
+    "CacheKey",
+]

--- a/src/seme/bytecode_disassembler.py
+++ b/src/seme/bytecode_disassembler.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, OpCode
+from seme.runtime import RuntimeValue, SemeBool, SemeInt, SemeString, format_runtime_value
+from seme.source_mapping import source_span_for_offset
+
+
+def disassemble_chunk(chunk: Chunk) -> list[str]:
+    lines: list[str] = []
+    for offset, instruction in enumerate(chunk.instructions):
+        span = source_span_for_offset(chunk, offset)
+        operands = _format_operands(chunk, instruction.opcode, instruction.operands)
+        operand_suffix = f" {operands}" if operands else ""
+        lines.append(
+            f"{offset:04d} {instruction.opcode.value}{operand_suffix} ; {span.line}:{span.column}"
+        )
+    return lines
+
+
+def _format_operands(chunk: Chunk, opcode: OpCode, operands: tuple[int, ...]) -> str:
+    if not operands:
+        return ""
+
+    if opcode == OpCode.LOAD_CONST:
+        const_index = operands[0]
+        if const_index < len(chunk.constants):
+            return f"{const_index} ({_format_constant(chunk.constants[const_index])})"
+        return str(const_index)
+
+    if opcode in (OpCode.LOAD_GLOBAL, OpCode.DEFINE_GLOBAL, OpCode.STORE_GLOBAL):
+        name_index = operands[0]
+        if name_index < len(chunk.constants):
+            return f"{name_index} ({_format_constant(chunk.constants[name_index])})"
+        return str(name_index)
+
+    return " ".join(str(operand) for operand in operands)
+
+
+def _format_constant(value: RuntimeValue) -> str:
+    if isinstance(value, (SemeInt, SemeBool, SemeString)):
+        return format_runtime_value(value)
+    return repr(value)
+
+
+__all__ = [
+    "disassemble_chunk",
+]

--- a/src/seme/bytecode_peephole.py
+++ b/src/seme/bytecode_peephole.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
+from seme.runtime import (
+    RuntimeValue,
+    SemeBool,
+    SemeInt,
+    runtime_arithmetic,
+    runtime_compare,
+    runtime_equal,
+    runtime_negate,
+    runtime_not,
+    same_runtime_type,
+)
+
+
+@dataclass(frozen=True)
+class PeepholeRecord:
+    instruction: Instruction
+    span: SourceSpan
+    source_offsets: tuple[int, ...]
+    folded_constant: RuntimeValue | None = None
+
+
+def optimize_chunk(chunk: Chunk, *, max_passes: int = 8) -> Chunk:
+    current = chunk
+    for _ in range(max_passes):
+        optimized, changed = _optimize_once(current)
+        if not changed:
+            return current
+        current = optimized
+    return current
+
+
+def _optimize_once(chunk: Chunk) -> tuple[Chunk, bool]:
+    records: list[PeepholeRecord] = []
+    offset_map: dict[int, int] = {}
+    changed = False
+    offset = 0
+    while offset < len(chunk.instructions):
+        constant_fold = _try_fold_constants(chunk, offset)
+        if constant_fold is not None:
+            instruction, span, consumed_offsets, folded_constant = constant_fold
+            output_offset = len(records)
+            records.append(
+                PeepholeRecord(
+                    instruction=instruction,
+                    span=span,
+                    source_offsets=consumed_offsets,
+                    folded_constant=folded_constant,
+                )
+            )
+            for consumed_offset in consumed_offsets:
+                offset_map[consumed_offset] = output_offset
+            offset += len(consumed_offsets)
+            changed = True
+            continue
+
+        if _is_const_pop(chunk, offset):
+            output_offset = len(records)
+            offset_map[offset] = output_offset
+            offset_map[offset + 1] = output_offset
+            offset += 2
+            changed = True
+            continue
+
+        instruction = chunk.instructions[offset]
+        records.append(
+            PeepholeRecord(
+                instruction=instruction,
+                span=chunk.span_for_offset(offset),
+                source_offsets=(offset,),
+            )
+        )
+        offset_map[offset] = len(records) - 1
+        offset += 1
+
+    optimized = Chunk(constants=list(chunk.constants))
+    for record in records:
+        instruction = record.instruction
+        operands = instruction.operands
+        if record.folded_constant is not None:
+            constant_index = optimized.add_constant(record.folded_constant)
+            optimized.emit(OpCode.LOAD_CONST, constant_index, span=record.span)
+            continue
+
+        if instruction.opcode in (OpCode.JUMP, OpCode.JUMP_IF_FALSE):
+            if len(operands) != 1:
+                optimized.emit(instruction.opcode, *operands, span=record.span)
+                continue
+            target_offset = operands[0]
+            if target_offset not in offset_map:
+                optimized.emit(instruction.opcode, *operands, span=record.span)
+                continue
+            optimized.emit(instruction.opcode, offset_map[target_offset], span=record.span)
+            continue
+
+        optimized.emit(instruction.opcode, *operands, span=record.span)
+
+    return optimized, changed
+
+
+def _is_const_pop(chunk: Chunk, offset: int) -> bool:
+    if offset + 1 >= len(chunk.instructions):
+        return False
+    first = chunk.instructions[offset]
+    second = chunk.instructions[offset + 1]
+    return first.opcode == OpCode.LOAD_CONST and second.opcode == OpCode.POP
+
+
+def _try_fold_constants(
+    chunk: Chunk,
+    offset: int,
+) -> tuple[Instruction, SourceSpan, tuple[int, ...], RuntimeValue] | None:
+    if offset + 1 >= len(chunk.instructions):
+        return None
+
+    first = chunk.instructions[offset]
+    second = chunk.instructions[offset + 1]
+    second_span = chunk.span_for_offset(offset + 1)
+
+    if first.opcode == OpCode.LOAD_CONST and second.opcode in (OpCode.NEGATE, OpCode.NOT):
+        operand = _constant_at(chunk, first)
+        if operand is None:
+            return None
+        if second.opcode == OpCode.NEGATE and isinstance(operand, SemeInt):
+            return (
+                Instruction(opcode=OpCode.LOAD_CONST, operands=()),
+                second_span,
+                (offset, offset + 1),
+                runtime_negate(operand),
+            )
+        if second.opcode == OpCode.NOT and isinstance(operand, SemeBool):
+            return (
+                Instruction(opcode=OpCode.LOAD_CONST, operands=()),
+                second_span,
+                (offset, offset + 1),
+                runtime_not(operand),
+            )
+        return None
+
+    if offset + 2 >= len(chunk.instructions):
+        return None
+
+    third = chunk.instructions[offset + 2]
+    third_span = chunk.span_for_offset(offset + 2)
+    if first.opcode != OpCode.LOAD_CONST or second.opcode != OpCode.LOAD_CONST:
+        return None
+    left = _constant_at(chunk, first)
+    right = _constant_at(chunk, second)
+    if left is None or right is None:
+        return None
+
+    if third.opcode in (OpCode.ADD, OpCode.SUB, OpCode.MUL, OpCode.DIV, OpCode.MOD):
+        if not isinstance(left, SemeInt) or not isinstance(right, SemeInt):
+            return None
+        if third.opcode in (OpCode.DIV, OpCode.MOD) and right.value == 0:
+            return None
+        operator = {
+            OpCode.ADD: "add",
+            OpCode.SUB: "sub",
+            OpCode.MUL: "mul",
+            OpCode.DIV: "div",
+            OpCode.MOD: "mod",
+        }[third.opcode]
+        return (
+            Instruction(opcode=OpCode.LOAD_CONST, operands=()),
+            third_span,
+            (offset, offset + 1, offset + 2),
+            runtime_arithmetic(operator, left, right),
+        )
+
+    if third.opcode in (OpCode.LESS, OpCode.LESS_EQUAL, OpCode.GREATER, OpCode.GREATER_EQUAL):
+        if not isinstance(left, SemeInt) or not isinstance(right, SemeInt):
+            return None
+        operator = {
+            OpCode.LESS: "lt",
+            OpCode.LESS_EQUAL: "lte",
+            OpCode.GREATER: "gt",
+            OpCode.GREATER_EQUAL: "gte",
+        }[third.opcode]
+        return (
+            Instruction(opcode=OpCode.LOAD_CONST, operands=()),
+            third_span,
+            (offset, offset + 1, offset + 2),
+            runtime_compare(operator, left, right),
+        )
+
+    if third.opcode in (OpCode.EQUAL, OpCode.NOT_EQUAL):
+        if not same_runtime_type(left, right):
+            return None
+        if third.opcode == OpCode.EQUAL:
+            operator = "eq"
+        else:
+            operator = "neq"
+        return (
+            Instruction(opcode=OpCode.LOAD_CONST, operands=()),
+            third_span,
+            (offset, offset + 1, offset + 2),
+            runtime_equal(operator, left, right),
+        )
+
+    return None
+
+
+def _constant_at(chunk: Chunk, instruction: Instruction) -> RuntimeValue | None:
+    if instruction.opcode != OpCode.LOAD_CONST or len(instruction.operands) != 1:
+        return None
+    const_index = instruction.operands[0]
+    if const_index >= len(chunk.constants):
+        return None
+    return chunk.constants[const_index]
+
+
+__all__ = [
+    "optimize_chunk",
+]

--- a/src/seme/bytecode_serialization.py
+++ b/src/seme/bytecode_serialization.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
+from seme.runtime import HeapRef, SemeBool, SemeInt, SemeString, RuntimeValue, RuntimeValueError
+
+
+def serialize_runtime_value(value: RuntimeValue) -> dict[str, object]:
+    if isinstance(value, SemeInt):
+        return {"kind": "int", "value": value.value}
+    if isinstance(value, SemeBool):
+        return {"kind": "bool", "value": value.value}
+    if isinstance(value, SemeString):
+        return {"kind": "string", "value": value.value}
+    if isinstance(value, HeapRef):
+        return {"kind": "heap_ref", "object_id": value.object_id, "ref_kind": value.kind}
+    raise RuntimeValueError(f"unsupported runtime value type {type(value).__name__}")
+
+
+def deserialize_runtime_value(payload: dict[str, object]) -> RuntimeValue:
+    kind = payload.get("kind")
+    if kind == "int":
+        return SemeInt(int(payload["value"]))
+    if kind == "bool":
+        return SemeBool(bool(payload["value"]))
+    if kind == "string":
+        return SemeString(str(payload["value"]))
+    if kind == "heap_ref":
+        return HeapRef(object_id=int(payload["object_id"]), kind=str(payload["ref_kind"]))
+    raise RuntimeValueError(f"unsupported serialized runtime value kind '{kind}'")
+
+
+def serialize_chunk(chunk: Chunk) -> str:
+    payload = {
+        "instructions": [
+            {
+                "opcode": instruction.opcode.value,
+                "operands": list(instruction.operands),
+            }
+            for instruction in chunk.instructions
+        ],
+        "constants": [serialize_runtime_value(value) for value in chunk.constants],
+        "source_map": [asdict(span) for span in chunk.source_map],
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def deserialize_chunk(data: str) -> Chunk:
+    payload = json.loads(data)
+    chunk = Chunk()
+    chunk.constants.extend(deserialize_runtime_value(value) for value in payload["constants"])
+    chunk.instructions.extend(
+        Instruction(opcode=OpCode(item["opcode"]), operands=tuple(int(op) for op in item["operands"]))
+        for item in payload["instructions"]
+    )
+    chunk.source_map.extend(SourceSpan(line=int(span["line"]), column=int(span["column"])) for span in payload["source_map"])
+    return chunk
+
+
+__all__ = [
+    "deserialize_chunk",
+    "deserialize_runtime_value",
+    "serialize_chunk",
+    "serialize_runtime_value",
+]

--- a/src/seme/bytecode_validator.py
+++ b/src/seme/bytecode_validator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
+from seme.diagnostics import Diagnostic
+from seme.runtime import is_string_value
+from seme.source_mapping import source_span_for_offset
+
+
+def validate_chunk(chunk: Chunk) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+
+    if len(chunk.instructions) != len(chunk.source_map):
+        diagnostics.append(
+            Diagnostic(
+                code="BYTECODE-001",
+                message="bytecode chunk instructions and source map lengths must match",
+                line=1,
+                column=1,
+            )
+        )
+        return diagnostics
+
+    for offset, instruction in enumerate(chunk.instructions):
+        span = source_span_for_offset(chunk, offset)
+        diagnostics.extend(_validate_instruction(chunk, instruction, span, offset))
+
+    return diagnostics
+
+
+def _validate_instruction(
+    chunk: Chunk,
+    instruction: Instruction,
+    span: SourceSpan,
+    offset: int,
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    opcode = instruction.opcode
+    operands = instruction.operands
+
+    def add_diag(message: str, code: str = "BYTECODE-002") -> None:
+        diagnostics.append(Diagnostic(code=code, message=message, line=span.line, column=span.column))
+
+    if opcode in (OpCode.LOAD_CONST, OpCode.LOAD_GLOBAL, OpCode.DEFINE_GLOBAL, OpCode.STORE_GLOBAL, OpCode.LOAD_LOCAL, OpCode.STORE_LOCAL):
+        if len(operands) != 1:
+            add_diag(f"{opcode.value} expects exactly one operand")
+            return diagnostics
+        operand = operands[0]
+        if operand < 0:
+            add_diag(f"{opcode.value} operand must be non-negative")
+            return diagnostics
+        if opcode == OpCode.LOAD_CONST:
+            if operand >= len(chunk.constants):
+                add_diag(f"{opcode.value} constant index {operand} is out of range")
+                return diagnostics
+            return diagnostics
+        if opcode in (OpCode.LOAD_GLOBAL, OpCode.DEFINE_GLOBAL, OpCode.STORE_GLOBAL):
+            if operand >= len(chunk.constants):
+                add_diag(f"{opcode.value} name constant index {operand} is out of range")
+                return diagnostics
+            if not is_string_value(chunk.constants[operand]):
+                add_diag(f"{opcode.value} requires a string constant operand")
+            return diagnostics
+        return diagnostics
+
+    if opcode in (OpCode.LOAD_UNINITIALIZED, OpCode.POP, OpCode.ADD, OpCode.SUB, OpCode.MUL, OpCode.DIV, OpCode.MOD, OpCode.NEGATE, OpCode.NOT, OpCode.EQUAL, OpCode.NOT_EQUAL, OpCode.LESS, OpCode.LESS_EQUAL, OpCode.GREATER, OpCode.GREATER_EQUAL, OpCode.PRINT, OpCode.RETURN):
+        if operands:
+            add_diag(f"{opcode.value} expects no operands")
+        return diagnostics
+
+    if opcode in (OpCode.POP_N, OpCode.JUMP, OpCode.JUMP_IF_FALSE):
+        if len(operands) != 1:
+            add_diag(f"{opcode.value} expects exactly one operand")
+            return diagnostics
+        operand = operands[0]
+        if operand < 0:
+            add_diag(f"{opcode.value} operand must be non-negative")
+            return diagnostics
+        if opcode in (OpCode.JUMP, OpCode.JUMP_IF_FALSE) and operand >= len(chunk.instructions):
+            add_diag(f"{opcode.value} target {operand} is out of range")
+        return diagnostics
+
+    add_diag(f"unsupported opcode {opcode.value}")
+    return diagnostics
+
+
+__all__ = [
+    "validate_chunk",
+]

--- a/src/seme/cli.py
+++ b/src/seme/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from seme.ast import Program, Stmt
 from seme.compiler import compile_program
+from seme.bytecode_disassembler import disassemble_chunk
 from seme.diagnostics import Diagnostic
 from seme.lexer import lex
 from seme.parser import parse
@@ -56,6 +57,35 @@ def _cmd_run(file_path: str, backend: ExecutionBackend) -> int:
     if diagnostics:
         _print_diagnostics(diagnostics, sys.stderr)
         return 1
+    return 0
+
+
+def _cmd_debug_bytecode(file_path: str) -> int:
+    path = Path(file_path)
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"RUNTIME-001 1:1 Failed to read file: {exc}", file=sys.stderr)
+        return 1
+
+    tokens, lex_diags = lex(source)
+    if lex_diags:
+        _print_diagnostics(lex_diags, sys.stderr)
+        return 1
+
+    program, parse_diags = parse(tokens)
+    if parse_diags:
+        _print_diagnostics(parse_diags, sys.stderr)
+        return 1
+
+    type_diags = check_types(program)
+    if type_diags:
+        _print_diagnostics(type_diags, sys.stderr)
+        return 1
+
+    chunk = compile_program(program)
+    for line in disassemble_chunk(chunk):
+        print(line)
     return 0
 
 
@@ -156,6 +186,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Execution backend to use for seme run.",
     )
 
+    debug_parser = sub.add_parser("debug")
+    debug_sub = debug_parser.add_subparsers(dest="debug_command", required=True)
+    bytecode_parser = debug_sub.add_parser("bytecode")
+    bytecode_parser.add_argument("file")
+
     sub.add_parser("repl")
 
     args = parser.parse_args(argv)
@@ -164,6 +199,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_check(args.file)
     if args.command == "run":
         return _cmd_run(args.file, backend=args.backend)
+    if args.command == "debug" and args.debug_command == "bytecode":
+        return _cmd_debug_bytecode(args.file)
     if args.command == "repl":
         return _cmd_repl()
 

--- a/src/seme/cli.py
+++ b/src/seme/cli.py
@@ -10,7 +10,7 @@ from seme.diagnostics import Diagnostic
 from seme.interpreter import Interpreter
 from seme.lexer import lex
 from seme.parser import parse
-from seme.pipeline import run_check, run_execute
+from seme.pipeline import ExecutionBackend, run_check, run_execute
 from seme.typechecker import check_types
 
 
@@ -41,7 +41,7 @@ def _cmd_check(file_path: str) -> int:
     return 0
 
 
-def _cmd_run(file_path: str) -> int:
+def _cmd_run(file_path: str, backend: ExecutionBackend) -> int:
     path = Path(file_path)
     try:
         source = path.read_text(encoding="utf-8")
@@ -49,7 +49,7 @@ def _cmd_run(file_path: str) -> int:
         print(f"RUNTIME-001 1:1 Failed to read file: {exc}", file=sys.stderr)
         return 1
 
-    stdout_text, diagnostics = run_execute(source)
+    stdout_text, diagnostics = run_execute(source, backend=backend)
     if stdout_text:
         sys.stdout.write(stdout_text)
     if diagnostics:
@@ -149,6 +149,12 @@ def main(argv: list[str] | None = None) -> int:
 
     run_parser = sub.add_parser("run")
     run_parser.add_argument("file")
+    run_parser.add_argument(
+        "--backend",
+        choices=("vm", "interpreter"),
+        default="vm",
+        help="Execution backend to use for seme run.",
+    )
 
     sub.add_parser("repl")
 
@@ -157,7 +163,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "check":
         return _cmd_check(args.file)
     if args.command == "run":
-        return _cmd_run(args.file)
+        return _cmd_run(args.file, backend=args.backend)
     if args.command == "repl":
         return _cmd_repl()
 

--- a/src/seme/cli.py
+++ b/src/seme/cli.py
@@ -6,12 +6,13 @@ from io import TextIOBase
 from pathlib import Path
 
 from seme.ast import Program, Stmt
+from seme.compiler import compile_program
 from seme.diagnostics import Diagnostic
-from seme.interpreter import Interpreter
 from seme.lexer import lex
 from seme.parser import parse
 from seme.pipeline import ExecutionBackend, run_check, run_execute
 from seme.typechecker import check_types
+from seme.vm import execute_chunk
 
 
 def _format_diagnostic(diag: Diagnostic) -> str:
@@ -65,9 +66,14 @@ def _program_for_history(statements: list[Stmt]) -> Program:
     return Program(statements=list(statements), line=first.line, column=first.column)
 
 
+def _execute_repl_program(program: Program) -> tuple[list[str], list[Diagnostic]]:
+    chunk = compile_program(program)
+    return execute_chunk(chunk)
+
+
 def repl_loop(inp: TextIOBase, out: TextIOBase, err: TextIOBase) -> int:
     history: list[Stmt] = []
-    interpreter = Interpreter()
+    committed_stdout_lines: list[str] = []
 
     while True:
         out.write("seme> ")
@@ -115,25 +121,19 @@ def repl_loop(inp: TextIOBase, out: TextIOBase, err: TextIOBase) -> int:
             _print_diagnostics(type_diags, err)
             continue
 
-        stmt_program = Program(statements=[stmt], line=stmt.line, column=stmt.column)
-        stdout_lines, runtime_diags = interpreter.execute(stmt_program)
-        for runtime_line in stdout_lines:
+        candidate_program = _program_for_history(history + [stmt])
+        stdout_lines, runtime_diags = _execute_repl_program(candidate_program)
+        new_stdout_lines = stdout_lines[len(committed_stdout_lines):]
+        for runtime_line in new_stdout_lines:
             out.write(f"{runtime_line}\n")
         out.flush()
 
         if runtime_diags:
             _print_diagnostics(runtime_diags, err)
-
-            interpreter = Interpreter()
-            if history:
-                _, rebuild_diags = interpreter.execute(_program_for_history(history))
-                if rebuild_diags:
-                    _print_diagnostics(rebuild_diags, err)
-                    history = []
-                    interpreter = Interpreter()
             continue
 
         history.append(stmt)
+        committed_stdout_lines = stdout_lines
 
 
 def _cmd_repl() -> int:

--- a/src/seme/compiler.py
+++ b/src/seme/compiler.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 
 from seme.ast import Assign, Binary, Block, Call, ConstDecl, Expr, ExprStmt, For, Grouping, Identifier, If, LetDecl, Literal, Program, Stmt, Unary, While
 from seme.bytecode import Chunk, GlobalInfo, LocalInfo, OpCode, SourceSpan
+from seme.bytecode_disassembler import disassemble_chunk
+from seme.bytecode_peephole import optimize_chunk
 from seme.runtime import RuntimeValue, make_runtime_value
 from seme.token import TokenKind
 
@@ -107,15 +109,7 @@ class BytecodeBuilder:
         )
 
     def render(self) -> list[str]:
-        rendered: list[str] = []
-        for offset, instruction in enumerate(self.chunk.instructions):
-            span = self.chunk.span_for_offset(offset)
-            operands = " ".join(str(operand) for operand in instruction.operands)
-            suffix = f" {operands}" if operands else ""
-            rendered.append(
-                f"{offset:04d} {instruction.opcode.value}{suffix} ; {span.line}:{span.column}"
-            )
-        return rendered
+        return disassemble_chunk(self.chunk)
 
 
 __all__ = [
@@ -126,14 +120,18 @@ __all__ = [
 
 
 class Compiler:
-    def __init__(self) -> None:
+    def __init__(self, *, optimize: bool = True) -> None:
         self.builder = BytecodeBuilder()
+        self.optimize = optimize
 
     def compile(self, program: Program) -> Chunk:
         for stmt in program.statements:
             self._compile_stmt(stmt)
         self.builder.emit(OpCode.RETURN, span=SourceSpan(program.line, program.column))
-        return self.builder.chunk
+        chunk = self.builder.chunk
+        if self.optimize:
+            return optimize_chunk(chunk)
+        return chunk
 
     def _compile_stmt(self, stmt: Stmt) -> None:
         if isinstance(stmt, LetDecl):
@@ -411,8 +409,8 @@ class Compiler:
         return self.builder.add_literal_constant(name)
 
 
-def compile_program(program: Program) -> Chunk:
-    return Compiler().compile(program)
+def compile_program(program: Program, *, optimize: bool = True) -> Chunk:
+    return Compiler(optimize=optimize).compile(program)
 
 
 __all__ = [

--- a/src/seme/compiler.py
+++ b/src/seme/compiler.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from seme.ast import Assign, Binary, Block, Call, ConstDecl, Expr, ExprStmt, For, Grouping, Identifier, If, LetDecl, Literal, Program, Stmt, Unary, While
+from seme.bytecode import Chunk, LocalInfo, OpCode, SourceSpan
+from seme.token import TokenKind
+
+
+@dataclass
+class Label:
+    name: str | None = None
+    offset: int | None = None
+    patch_sites: list[int] = field(default_factory=list)
+
+
+@dataclass
+class CompilerState:
+    chunk: Chunk = field(default_factory=Chunk)
+    locals: list[LocalInfo] = field(default_factory=list)
+    scope_depth: int = 0
+
+    def begin_scope(self) -> None:
+        self.scope_depth += 1
+
+    def end_scope(self) -> list[LocalInfo]:
+        to_drop = [local for local in self.locals if local.depth == self.scope_depth]
+        self.locals = [local for local in self.locals if local.depth != self.scope_depth]
+        if self.scope_depth > 0:
+            self.scope_depth -= 1
+        return to_drop
+
+    def declare_local(self, name: str, *, is_const: bool) -> LocalInfo:
+        local = LocalInfo(
+            name=name,
+            slot=len(self.locals),
+            depth=self.scope_depth,
+            is_const=is_const,
+        )
+        self.locals.append(local)
+        return local
+
+    def resolve_local(self, name: str) -> LocalInfo | None:
+        for local in reversed(self.locals):
+            if local.name == name:
+                return local
+        return None
+
+
+class BytecodeBuilder:
+    def __init__(self, state: CompilerState | None = None) -> None:
+        self.state = state or CompilerState()
+
+    @property
+    def chunk(self) -> Chunk:
+        return self.state.chunk
+
+    def add_constant(self, value: int | bool | str) -> int:
+        return self.chunk.add_constant(value)
+
+    def emit(self, opcode: OpCode, *operands: int, span: SourceSpan) -> int:
+        return self.chunk.emit(opcode, *operands, span=span)
+
+    def new_label(self, name: str | None = None) -> Label:
+        return Label(name=name)
+
+    def bind_label(self, label: Label) -> int:
+        if label.offset is not None:
+            raise ValueError("label is already bound")
+        label.offset = len(self.chunk.instructions)
+        for patch_site in label.patch_sites:
+            self.patch_jump(patch_site, label.offset)
+        label.patch_sites.clear()
+        return label.offset
+
+    def emit_jump(self, opcode: OpCode, label: Label, *, span: SourceSpan) -> int:
+        if opcode not in (OpCode.JUMP, OpCode.JUMP_IF_FALSE):
+            raise ValueError(f"opcode {opcode} is not a jump instruction")
+        target = label.offset if label.offset is not None else -1
+        offset = self.emit(opcode, target, span=span)
+        if label.offset is None:
+            label.patch_sites.append(offset)
+        return offset
+
+    def patch_jump(self, offset: int, target: int) -> None:
+        instruction = self.chunk.instructions[offset]
+        if instruction.opcode not in (OpCode.JUMP, OpCode.JUMP_IF_FALSE):
+            raise ValueError("only jump instructions can be patched")
+        if len(instruction.operands) != 1:
+            raise ValueError("jump instructions must carry exactly one target operand")
+        self.chunk.instructions[offset] = type(instruction)(
+            opcode=instruction.opcode,
+            operands=(target,),
+        )
+
+    def render(self) -> list[str]:
+        rendered: list[str] = []
+        for offset, instruction in enumerate(self.chunk.instructions):
+            span = self.chunk.span_for_offset(offset)
+            operands = " ".join(str(operand) for operand in instruction.operands)
+            suffix = f" {operands}" if operands else ""
+            rendered.append(
+                f"{offset:04d} {instruction.opcode.value}{suffix} ; {span.line}:{span.column}"
+            )
+        return rendered
+
+
+__all__ = [
+    "BytecodeBuilder",
+    "CompilerState",
+    "Label",
+]
+
+
+class Compiler:
+    def __init__(self) -> None:
+        self.builder = BytecodeBuilder()
+
+    def compile(self, program: Program) -> Chunk:
+        for stmt in program.statements:
+            self._compile_stmt(stmt)
+        self.builder.emit(OpCode.RETURN, span=SourceSpan(program.line, program.column))
+        return self.builder.chunk
+
+    def _compile_stmt(self, stmt: Stmt) -> None:
+        if isinstance(stmt, LetDecl):
+            local = self.builder.state.declare_local(stmt.name, is_const=False)
+            if stmt.initializer is None:
+                self.builder.emit(OpCode.LOAD_UNINITIALIZED, span=SourceSpan(stmt.line, stmt.column))
+            else:
+                self._compile_expr(stmt.initializer)
+            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+            return
+
+        if isinstance(stmt, ConstDecl):
+            local = self.builder.state.declare_local(stmt.name, is_const=True)
+            self._compile_expr(stmt.initializer)
+            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+            return
+
+        if isinstance(stmt, Assign):
+            local = self._require_local(stmt.name, stmt.line, stmt.column)
+            self._compile_expr(stmt.value)
+            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+            return
+
+        if isinstance(stmt, ExprStmt):
+            expr = stmt.expression
+            if self._is_print_stmt(expr):
+                self._compile_expr(expr.arguments[0])
+                self.builder.emit(OpCode.PRINT, span=SourceSpan(expr.line, expr.column))
+                return
+            self._compile_expr(expr)
+            self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+            return
+
+        if isinstance(stmt, Block):
+            self._compile_block(stmt)
+            return
+
+        if isinstance(stmt, If):
+            self._compile_if(stmt)
+            return
+
+        if isinstance(stmt, While):
+            self._compile_while(stmt)
+            return
+
+        if isinstance(stmt, For):
+            self._compile_for(stmt)
+            return
+
+        raise NotImplementedError(f"statement compilation not implemented for {type(stmt).__name__}")
+
+    def _compile_expr(self, expr: Expr) -> None:
+        if isinstance(expr, Literal):
+            const_index = self.builder.add_constant(expr.value)
+            self.builder.emit(OpCode.LOAD_CONST, const_index, span=SourceSpan(expr.line, expr.column))
+            return
+
+        if isinstance(expr, Identifier):
+            local = self._require_local(expr.name, expr.line, expr.column)
+            self.builder.emit(OpCode.LOAD_LOCAL, local.slot, span=SourceSpan(expr.line, expr.column))
+            return
+
+        if isinstance(expr, Grouping):
+            self._compile_expr(expr.expression)
+            return
+
+        if isinstance(expr, Unary):
+            self._compile_expr(expr.operand)
+            if expr.operator == TokenKind.MINUS:
+                self.builder.emit(OpCode.NEGATE, span=SourceSpan(expr.line, expr.column))
+                return
+            if expr.operator == TokenKind.BANG:
+                self.builder.emit(OpCode.NOT, span=SourceSpan(expr.line, expr.column))
+                return
+            raise NotImplementedError(f"unsupported unary operator {expr.operator}")
+
+        if isinstance(expr, Binary):
+            if expr.operator in (TokenKind.ANDAND, TokenKind.OROR):
+                self._compile_logical(expr)
+                return
+            self._compile_expr(expr.left)
+            self._compile_expr(expr.right)
+            self.builder.emit(self._binary_opcode(expr.operator), span=SourceSpan(expr.line, expr.column))
+            return
+
+        if isinstance(expr, Call) and self._is_print_stmt(expr):
+            raise NotImplementedError("print(expr) is only supported in statement position")
+
+        raise NotImplementedError(f"expression compilation not implemented for {type(expr).__name__}")
+
+    def _compile_logical(self, expr: Binary) -> None:
+        self._compile_expr(expr.left)
+        short_circuit_label = self.builder.new_label("logical_short_circuit")
+        done_label = self.builder.new_label("logical_done")
+
+        if expr.operator == TokenKind.ANDAND:
+            self.builder.emit_jump(OpCode.JUMP_IF_FALSE, short_circuit_label, span=SourceSpan(expr.line, expr.column))
+            self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
+            self._compile_expr(expr.right)
+            self.builder.emit_jump(OpCode.JUMP, done_label, span=SourceSpan(expr.line, expr.column))
+            self.builder.bind_label(short_circuit_label)
+            self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
+            false_index = self.builder.add_constant(False)
+            self.builder.emit(OpCode.LOAD_CONST, false_index, span=SourceSpan(expr.line, expr.column))
+            self.builder.bind_label(done_label)
+            return
+
+        self.builder.emit_jump(OpCode.JUMP_IF_FALSE, short_circuit_label, span=SourceSpan(expr.line, expr.column))
+        true_index = self.builder.add_constant(True)
+        self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
+        self.builder.emit(OpCode.LOAD_CONST, true_index, span=SourceSpan(expr.line, expr.column))
+        self.builder.emit_jump(OpCode.JUMP, done_label, span=SourceSpan(expr.line, expr.column))
+        self.builder.bind_label(short_circuit_label)
+        self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
+        self._compile_expr(expr.right)
+        self.builder.bind_label(done_label)
+
+    def _binary_opcode(self, operator: TokenKind) -> OpCode:
+        opcodes = {
+            TokenKind.PLUS: OpCode.ADD,
+            TokenKind.MINUS: OpCode.SUB,
+            TokenKind.STAR: OpCode.MUL,
+            TokenKind.SLASH: OpCode.DIV,
+            TokenKind.PERCENT: OpCode.MOD,
+            TokenKind.EQEQ: OpCode.EQUAL,
+            TokenKind.NEQ: OpCode.NOT_EQUAL,
+            TokenKind.LT: OpCode.LESS,
+            TokenKind.LTE: OpCode.LESS_EQUAL,
+            TokenKind.GT: OpCode.GREATER,
+            TokenKind.GTE: OpCode.GREATER_EQUAL,
+        }
+        try:
+            return opcodes[operator]
+        except KeyError as exc:
+            raise NotImplementedError(f"unsupported binary operator {operator}") from exc
+
+    def _is_print_stmt(self, expr: Expr) -> bool:
+        return (
+            isinstance(expr, Call)
+            and isinstance(expr.callee, Identifier)
+            and expr.callee.name == "print"
+            and len(expr.arguments) == 1
+        )
+
+    def _compile_block(self, block: Block) -> None:
+        self.builder.state.begin_scope()
+        try:
+            for stmt in block.statements:
+                self._compile_stmt(stmt)
+        finally:
+            self._emit_scope_cleanup(block.line, block.column)
+
+    def _compile_if(self, stmt: If) -> None:
+        self._compile_expr(stmt.condition)
+        else_label = self.builder.new_label("if_else")
+        done_label = self.builder.new_label("if_done")
+        self.builder.emit_jump(OpCode.JUMP_IF_FALSE, else_label, span=SourceSpan(stmt.line, stmt.column))
+        self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+        self._compile_stmt(stmt.then_branch)
+        self.builder.emit_jump(OpCode.JUMP, done_label, span=SourceSpan(stmt.line, stmt.column))
+        self.builder.bind_label(else_label)
+        self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+        if stmt.else_branch is not None:
+            self._compile_stmt(stmt.else_branch)
+        self.builder.bind_label(done_label)
+
+    def _compile_while(self, stmt: While) -> None:
+        loop_start = self.builder.new_label("while_start")
+        loop_end = self.builder.new_label("while_end")
+        self.builder.bind_label(loop_start)
+        self._compile_expr(stmt.condition)
+        self.builder.emit_jump(OpCode.JUMP_IF_FALSE, loop_end, span=SourceSpan(stmt.line, stmt.column))
+        self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+        self._compile_stmt(stmt.body)
+        self.builder.emit_jump(OpCode.JUMP, loop_start, span=SourceSpan(stmt.line, stmt.column))
+        self.builder.bind_label(loop_end)
+        self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+
+    def _compile_for(self, stmt: For) -> None:
+        self.builder.state.begin_scope()
+        try:
+            if stmt.init is not None:
+                self._compile_for_clause(stmt.init)
+
+            loop_start = self.builder.new_label("for_start")
+            loop_end = self.builder.new_label("for_end")
+            self.builder.bind_label(loop_start)
+
+            if stmt.condition is not None:
+                self._compile_expr(stmt.condition)
+                self.builder.emit_jump(OpCode.JUMP_IF_FALSE, loop_end, span=SourceSpan(stmt.line, stmt.column))
+                self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+
+            self._compile_stmt(stmt.body)
+
+            if stmt.update is not None:
+                self._compile_for_clause(stmt.update)
+
+            self.builder.emit_jump(OpCode.JUMP, loop_start, span=SourceSpan(stmt.line, stmt.column))
+            self.builder.bind_label(loop_end)
+            if stmt.condition is not None:
+                self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
+        finally:
+            self._emit_scope_cleanup(stmt.line, stmt.column)
+
+    def _compile_for_clause(self, clause: Stmt | Expr) -> None:
+        if isinstance(clause, Assign):
+            self._compile_stmt(clause)
+            return
+        if isinstance(clause, (LetDecl, ConstDecl, ExprStmt, Block, If, While, For)):
+            self._compile_stmt(clause)
+            return
+        self._compile_expr(clause)
+        self.builder.emit(OpCode.POP, span=SourceSpan(clause.line, clause.column))
+
+    def _emit_scope_cleanup(self, line: int, column: int) -> None:
+        dropped = self.builder.state.end_scope()
+        if dropped:
+            self.builder.emit(OpCode.POP_N, len(dropped), span=SourceSpan(line, column))
+
+    def _require_local(self, name: str, line: int, column: int) -> LocalInfo:
+        local = self.builder.state.resolve_local(name)
+        if local is None:
+            raise ValueError(f"unresolved local '{name}' at {line}:{column}")
+        return local
+
+
+def compile_program(program: Program) -> Chunk:
+    return Compiler().compile(program)
+
+
+__all__ = [
+    "BytecodeBuilder",
+    "Compiler",
+    "CompilerState",
+    "Label",
+    "compile_program",
+]

--- a/src/seme/compiler.py
+++ b/src/seme/compiler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from seme.ast import Assign, Binary, Block, Call, ConstDecl, Expr, ExprStmt, For, Grouping, Identifier, If, LetDecl, Literal, Program, Stmt, Unary, While
-from seme.bytecode import Chunk, LocalInfo, OpCode, SourceSpan
+from seme.bytecode import Chunk, GlobalInfo, LocalInfo, OpCode, SourceSpan
 from seme.runtime import RuntimeValue, make_runtime_value
 from seme.token import TokenKind
 
@@ -19,6 +19,7 @@ class Label:
 class CompilerState:
     chunk: Chunk = field(default_factory=Chunk)
     locals: list[LocalInfo] = field(default_factory=list)
+    globals: dict[str, GlobalInfo] = field(default_factory=dict)
     scope_depth: int = 0
 
     def begin_scope(self) -> None:
@@ -46,6 +47,14 @@ class CompilerState:
             if local.name == name:
                 return local
         return None
+
+    def declare_global(self, name: str, *, is_const: bool) -> GlobalInfo:
+        global_info = GlobalInfo(name=name, is_const=is_const)
+        self.globals[name] = global_info
+        return global_info
+
+    def resolve_global(self, name: str) -> GlobalInfo | None:
+        return self.globals.get(name)
 
 
 class BytecodeBuilder:
@@ -128,26 +137,56 @@ class Compiler:
 
     def _compile_stmt(self, stmt: Stmt) -> None:
         if isinstance(stmt, LetDecl):
-            local = self.builder.state.declare_local(stmt.name, is_const=False)
+            is_global = self.builder.state.scope_depth == 0
+            if is_global:
+                self.builder.state.declare_global(stmt.name, is_const=False)
+            else:
+                local = self.builder.state.declare_local(stmt.name, is_const=False)
             if stmt.initializer is None:
                 self.builder.emit(OpCode.LOAD_UNINITIALIZED, span=SourceSpan(stmt.line, stmt.column))
             else:
                 self._compile_expr(stmt.initializer)
-            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            if is_global:
+                self.builder.emit(
+                    OpCode.DEFINE_GLOBAL,
+                    self._name_constant_index(stmt.name),
+                    span=SourceSpan(stmt.line, stmt.column),
+                )
+            else:
+                self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
             self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
             return
 
         if isinstance(stmt, ConstDecl):
-            local = self.builder.state.declare_local(stmt.name, is_const=True)
+            is_global = self.builder.state.scope_depth == 0
+            if is_global:
+                self.builder.state.declare_global(stmt.name, is_const=True)
+            else:
+                local = self.builder.state.declare_local(stmt.name, is_const=True)
             self._compile_expr(stmt.initializer)
-            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            if is_global:
+                self.builder.emit(
+                    OpCode.DEFINE_GLOBAL,
+                    self._name_constant_index(stmt.name),
+                    span=SourceSpan(stmt.line, stmt.column),
+                )
+            else:
+                self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
             self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
             return
 
         if isinstance(stmt, Assign):
-            local = self._require_local(stmt.name, stmt.line, stmt.column)
             self._compile_expr(stmt.value)
-            self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            local = self.builder.state.resolve_local(stmt.name)
+            if local is not None:
+                self.builder.emit(OpCode.STORE_LOCAL, local.slot, span=SourceSpan(stmt.line, stmt.column))
+            else:
+                self._require_global(stmt.name, stmt.line, stmt.column)
+                self.builder.emit(
+                    OpCode.STORE_GLOBAL,
+                    self._name_constant_index(stmt.name),
+                    span=SourceSpan(stmt.line, stmt.column),
+                )
             self.builder.emit(OpCode.POP, span=SourceSpan(stmt.line, stmt.column))
             return
 
@@ -186,8 +225,16 @@ class Compiler:
             return
 
         if isinstance(expr, Identifier):
-            local = self._require_local(expr.name, expr.line, expr.column)
-            self.builder.emit(OpCode.LOAD_LOCAL, local.slot, span=SourceSpan(expr.line, expr.column))
+            local = self.builder.state.resolve_local(expr.name)
+            if local is not None:
+                self.builder.emit(OpCode.LOAD_LOCAL, local.slot, span=SourceSpan(expr.line, expr.column))
+                return
+            self._require_global(expr.name, expr.line, expr.column)
+            self.builder.emit(
+                OpCode.LOAD_GLOBAL,
+                self._name_constant_index(expr.name),
+                span=SourceSpan(expr.line, expr.column),
+            )
             return
 
         if isinstance(expr, Grouping):
@@ -353,6 +400,15 @@ class Compiler:
         if local is None:
             raise ValueError(f"unresolved local '{name}' at {line}:{column}")
         return local
+
+    def _require_global(self, name: str, line: int, column: int) -> GlobalInfo:
+        global_info = self.builder.state.resolve_global(name)
+        if global_info is None:
+            raise ValueError(f"unresolved global '{name}' at {line}:{column}")
+        return global_info
+
+    def _name_constant_index(self, name: str) -> int:
+        return self.builder.add_literal_constant(name)
 
 
 def compile_program(program: Program) -> Chunk:

--- a/src/seme/compiler.py
+++ b/src/seme/compiler.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 
 from seme.ast import Assign, Binary, Block, Call, ConstDecl, Expr, ExprStmt, For, Grouping, Identifier, If, LetDecl, Literal, Program, Stmt, Unary, While
 from seme.bytecode import Chunk, LocalInfo, OpCode, SourceSpan
+from seme.runtime import RuntimeValue, make_runtime_value
 from seme.token import TokenKind
 
 
@@ -55,8 +56,11 @@ class BytecodeBuilder:
     def chunk(self) -> Chunk:
         return self.state.chunk
 
-    def add_constant(self, value: int | bool | str) -> int:
+    def add_constant(self, value: RuntimeValue) -> int:
         return self.chunk.add_constant(value)
+
+    def add_literal_constant(self, value: int | bool | str) -> int:
+        return self.add_constant(make_runtime_value(value))
 
     def emit(self, opcode: OpCode, *operands: int, span: SourceSpan) -> int:
         return self.chunk.emit(opcode, *operands, span=span)
@@ -177,7 +181,7 @@ class Compiler:
 
     def _compile_expr(self, expr: Expr) -> None:
         if isinstance(expr, Literal):
-            const_index = self.builder.add_constant(expr.value)
+            const_index = self.builder.add_literal_constant(expr.value)
             self.builder.emit(OpCode.LOAD_CONST, const_index, span=SourceSpan(expr.line, expr.column))
             return
 
@@ -226,13 +230,13 @@ class Compiler:
             self.builder.emit_jump(OpCode.JUMP, done_label, span=SourceSpan(expr.line, expr.column))
             self.builder.bind_label(short_circuit_label)
             self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
-            false_index = self.builder.add_constant(False)
+            false_index = self.builder.add_literal_constant(False)
             self.builder.emit(OpCode.LOAD_CONST, false_index, span=SourceSpan(expr.line, expr.column))
             self.builder.bind_label(done_label)
             return
 
         self.builder.emit_jump(OpCode.JUMP_IF_FALSE, short_circuit_label, span=SourceSpan(expr.line, expr.column))
-        true_index = self.builder.add_constant(True)
+        true_index = self.builder.add_literal_constant(True)
         self.builder.emit(OpCode.POP, span=SourceSpan(expr.line, expr.column))
         self.builder.emit(OpCode.LOAD_CONST, true_index, span=SourceSpan(expr.line, expr.column))
         self.builder.emit_jump(OpCode.JUMP, done_label, span=SourceSpan(expr.line, expr.column))

--- a/src/seme/interpreter.py
+++ b/src/seme/interpreter.py
@@ -21,18 +21,17 @@ from seme.ast import (
     Unary,
     While,
 )
+from seme.builtins import DEFAULT_BUILTINS
 from seme.diagnostics import Diagnostic
 from seme.runtime import (
+    RuntimeHeap,
     RuntimeValue,
     RuntimeValueError,
     SemeBool,
-    SemeInt,
-    SemeString,
     StackValue,
     UNINITIALIZED,
-    VOID,
     expect_bool,
-    format_runtime_value,
+    is_runtime_value,
     make_runtime_value,
     require_runtime_value,
     runtime_arithmetic,
@@ -40,6 +39,11 @@ from seme.runtime import (
     runtime_equal,
     runtime_negate,
     runtime_not,
+)
+from seme.runtime_faults import (
+    RuntimeFault,
+    diagnostic_from_runtime_fault,
+    diagnostic_from_unexpected_runtime_error,
 )
 from seme.token import TokenKind
 
@@ -52,17 +56,24 @@ class RuntimeBinding:
     is_const: bool
 
 
-@dataclass(frozen=True)
-class RuntimeFault(Exception):
-    message: str
-    line: int
-    column: int
-
-
 class Interpreter:
     def __init__(self) -> None:
+        self.heap = RuntimeHeap()
         self.scopes: list[dict[str, RuntimeBinding]] = [{}]
         self.stdout_lines: list[str] = []
+
+    @property
+    def runtime_heap(self) -> RuntimeHeap:
+        return self.heap
+
+    def write_stdout_line(self, line: str) -> None:
+        self.stdout_lines.append(line)
+
+    def gc_root_values(self) -> list[StackValue]:
+        roots: list[StackValue] = []
+        for scope in self.scopes:
+            roots.extend(binding.value for binding in scope.values())
+        return roots
 
     def execute(self, program: Program) -> tuple[list[str], list[Diagnostic]]:
         start_index = len(self.stdout_lines)
@@ -72,20 +83,12 @@ class Interpreter:
                 self._eval_stmt(stmt)
             return self.stdout_lines[start_index:], diagnostics
         except RuntimeFault as err:
-            diagnostics.append(
-                Diagnostic(
-                    code="RUNTIME-001",
-                    message=f"Runtime error: {err.message}",
-                    line=err.line,
-                    column=err.column,
-                )
-            )
+            diagnostics.append(diagnostic_from_runtime_fault(err))
             return self.stdout_lines[start_index:], diagnostics
         except Exception as exc:  # pragma: no cover
             diagnostics.append(
-                Diagnostic(
-                    code="RUNTIME-001",
-                    message=f"Runtime error: {exc}",
+                diagnostic_from_unexpected_runtime_error(
+                    exc,
                     line=program.line,
                     column=program.column,
                 )
@@ -215,7 +218,7 @@ class Interpreter:
 
     def _eval_expr(self, expr: Expr) -> EvalValue:
         if isinstance(expr, Literal):
-            return make_runtime_value(expr.value)
+            return make_runtime_value(expr.value, heap=self.heap)
 
         if isinstance(expr, Identifier):
             return self._read(expr.name, expr.line, expr.column)
@@ -315,9 +318,9 @@ class Interpreter:
                 if op == TokenKind.GTE:
                     return runtime_compare("gte", left, right)
                 if op == TokenKind.EQEQ:
-                    return runtime_equal("eq", left, right)
+                    return runtime_equal("eq", left, right, heap=self.heap)
                 if op == TokenKind.NEQ:
-                    return runtime_equal("neq", left, right)
+                    return runtime_equal("neq", left, right, heap=self.heap)
                 self._runtime_error(expr.line, expr.column, "unsupported binary operator")
             except RuntimeValueError as err:
                 self._runtime_error(expr.line, expr.column, err.message)
@@ -325,15 +328,18 @@ class Interpreter:
         if isinstance(expr, Call):
             if not isinstance(expr.callee, Identifier) or expr.callee.name != "print":
                 self._runtime_error(expr.line, expr.column, "only print(expr) call is supported")
-            if len(expr.arguments) != 1:
-                self._runtime_error(expr.line, expr.column, "print requires exactly one argument")
-            value = self._require_runtime_value(
-                self._eval_expr(expr.arguments[0]),
-                expr.arguments[0].line,
-                expr.arguments[0].column,
-            )
-            self.stdout_lines.append(format_runtime_value(value))
-            return VOID
+            args = [
+                self._require_runtime_value(
+                    self._eval_expr(argument),
+                    argument.line,
+                    argument.column,
+                )
+                for argument in expr.arguments
+            ]
+            try:
+                return DEFAULT_BUILTINS.invoke(expr.callee.name, args, self)
+            except RuntimeValueError as err:
+                self._runtime_error(expr.line, expr.column, err.message)
 
         self._runtime_error(expr.line, expr.column, "unsupported expression")
 
@@ -379,7 +385,7 @@ class Interpreter:
             resolved = require_runtime_value(value)
         except RuntimeValueError as err:
             self._runtime_error(line, column, err.message)
-        if not isinstance(resolved, (SemeInt, SemeBool, SemeString)):
+        if not is_runtime_value(resolved):
             self._runtime_error(line, column, "invalid runtime value")
         return resolved
 

--- a/src/seme/interpreter.py
+++ b/src/seme/interpreter.py
@@ -22,12 +22,28 @@ from seme.ast import (
     While,
 )
 from seme.diagnostics import Diagnostic
+from seme.runtime import (
+    RuntimeValue,
+    RuntimeValueError,
+    SemeBool,
+    SemeInt,
+    SemeString,
+    StackValue,
+    UNINITIALIZED,
+    VOID,
+    expect_bool,
+    format_runtime_value,
+    make_runtime_value,
+    require_runtime_value,
+    runtime_arithmetic,
+    runtime_compare,
+    runtime_equal,
+    runtime_negate,
+    runtime_not,
+)
 from seme.token import TokenKind
 
-RuntimeValue = int | bool | str
-EvalValue = RuntimeValue | object
-_UNINITIALIZED = object()
-_VOID = object()
+EvalValue = StackValue
 
 
 @dataclass
@@ -79,7 +95,7 @@ class Interpreter:
     def _eval_stmt(self, stmt: Stmt) -> None:
         if isinstance(stmt, LetDecl):
             if stmt.initializer is None:
-                self._declare(stmt.name, _UNINITIALIZED, is_const=False, line=stmt.line, column=stmt.column)
+                self._declare(stmt.name, UNINITIALIZED, is_const=False, line=stmt.line, column=stmt.column)
             else:
                 self._declare(
                     stmt.name,
@@ -96,7 +112,7 @@ class Interpreter:
 
         if isinstance(stmt, ConstDecl):
             if stmt.initializer is None:
-                self._declare(stmt.name, _UNINITIALIZED, is_const=True, line=stmt.line, column=stmt.column)
+                self._declare(stmt.name, UNINITIALIZED, is_const=True, line=stmt.line, column=stmt.column)
             else:
                 self._declare(
                     stmt.name,
@@ -126,9 +142,11 @@ class Interpreter:
                 stmt.condition.line,
                 stmt.condition.column,
             )
-            if not isinstance(cond, bool):
-                self._runtime_error(stmt.condition.line, stmt.condition.column, "if condition must evaluate to bool")
-            if cond:
+            try:
+                cond_value = expect_bool(cond, "if condition must evaluate to bool")
+            except RuntimeValueError as err:
+                self._runtime_error(stmt.condition.line, stmt.condition.column, err.message)
+            if cond_value:
                 self._eval_stmt(stmt.then_branch)
             elif stmt.else_branch is not None:
                 self._eval_stmt(stmt.else_branch)
@@ -141,13 +159,11 @@ class Interpreter:
                     stmt.condition.line,
                     stmt.condition.column,
                 )
-                if not isinstance(cond, bool):
-                    self._runtime_error(
-                        stmt.condition.line,
-                        stmt.condition.column,
-                        "while condition must evaluate to bool",
-                    )
-                if not cond:
+                try:
+                    cond_value = expect_bool(cond, "while condition must evaluate to bool")
+                except RuntimeValueError as err:
+                    self._runtime_error(stmt.condition.line, stmt.condition.column, err.message)
+                if not cond_value:
                     break
                 self._eval_stmt(stmt.body)
             return
@@ -168,13 +184,11 @@ class Interpreter:
                             stmt.condition.line,
                             stmt.condition.column,
                         )
-                        if not isinstance(cond, bool):
-                            self._runtime_error(
-                                stmt.condition.line,
-                                stmt.condition.column,
-                                "for condition must evaluate to bool",
-                            )
-                        if not cond:
+                        try:
+                            cond_value = expect_bool(cond, "for condition must evaluate to bool")
+                        except RuntimeValueError as err:
+                            self._runtime_error(stmt.condition.line, stmt.condition.column, err.message)
+                        if not cond_value:
                             break
                     self._eval_stmt(stmt.body)
                     if stmt.update is not None:
@@ -201,7 +215,7 @@ class Interpreter:
 
     def _eval_expr(self, expr: Expr) -> EvalValue:
         if isinstance(expr, Literal):
-            return expr.value
+            return make_runtime_value(expr.value)
 
         if isinstance(expr, Identifier):
             return self._read(expr.name, expr.line, expr.column)
@@ -215,15 +229,14 @@ class Interpreter:
                 expr.operand.line,
                 expr.operand.column,
             )
-            if expr.operator == TokenKind.BANG:
-                if not isinstance(operand, bool):
-                    self._runtime_error(expr.line, expr.column, "operator '!' requires bool operand")
-                return not operand
-            if expr.operator == TokenKind.MINUS:
-                if not self._is_int(operand):
-                    self._runtime_error(expr.line, expr.column, "unary '-' requires int operand")
-                return -operand
-            self._runtime_error(expr.line, expr.column, "unsupported unary operator")
+            try:
+                if expr.operator == TokenKind.BANG:
+                    return runtime_not(operand)
+                if expr.operator == TokenKind.MINUS:
+                    return runtime_negate(operand)
+                self._runtime_error(expr.line, expr.column, "unsupported unary operator")
+            except RuntimeValueError as err:
+                self._runtime_error(expr.line, expr.column, err.message)
 
         if isinstance(expr, Binary):
             if expr.operator == TokenKind.ANDAND:
@@ -232,18 +245,21 @@ class Interpreter:
                     expr.left.line,
                     expr.left.column,
                 )
-                if not isinstance(left, bool):
-                    self._runtime_error(expr.line, expr.column, "operator '&&' requires bool operands")
-                if not left:
-                    return False
+                try:
+                    left_value = expect_bool(left, "operator '&&' requires bool operands")
+                except RuntimeValueError as err:
+                    self._runtime_error(expr.line, expr.column, err.message)
+                if not left_value:
+                    return SemeBool(False)
                 right = self._require_runtime_value(
                     self._eval_expr(expr.right),
                     expr.right.line,
                     expr.right.column,
                 )
-                if not isinstance(right, bool):
-                    self._runtime_error(expr.line, expr.column, "operator '&&' requires bool operands")
-                return left and right
+                try:
+                    return SemeBool(left_value and expect_bool(right, "operator '&&' requires bool operands"))
+                except RuntimeValueError as err:
+                    self._runtime_error(expr.line, expr.column, err.message)
 
             if expr.operator == TokenKind.OROR:
                 left = self._require_runtime_value(
@@ -251,18 +267,21 @@ class Interpreter:
                     expr.left.line,
                     expr.left.column,
                 )
-                if not isinstance(left, bool):
-                    self._runtime_error(expr.line, expr.column, "operator '||' requires bool operands")
-                if left:
-                    return True
+                try:
+                    left_value = expect_bool(left, "operator '||' requires bool operands")
+                except RuntimeValueError as err:
+                    self._runtime_error(expr.line, expr.column, err.message)
+                if left_value:
+                    return SemeBool(True)
                 right = self._require_runtime_value(
                     self._eval_expr(expr.right),
                     expr.right.line,
                     expr.right.column,
                 )
-                if not isinstance(right, bool):
-                    self._runtime_error(expr.line, expr.column, "operator '||' requires bool operands")
-                return left or right
+                try:
+                    return SemeBool(left_value or expect_bool(right, "operator '||' requires bool operands"))
+                except RuntimeValueError as err:
+                    self._runtime_error(expr.line, expr.column, err.message)
 
             left = self._require_runtime_value(
                 self._eval_expr(expr.left),
@@ -276,40 +295,32 @@ class Interpreter:
             )
             op = expr.operator
 
-            if op in (TokenKind.PLUS, TokenKind.MINUS, TokenKind.STAR, TokenKind.SLASH, TokenKind.PERCENT):
-                if not self._is_int(left) or not self._is_int(right):
-                    self._runtime_error(expr.line, expr.column, "arithmetic operators require int operands")
+            try:
                 if op == TokenKind.PLUS:
-                    return left + right
+                    return runtime_arithmetic("add", left, right)
                 if op == TokenKind.MINUS:
-                    return left - right
+                    return runtime_arithmetic("sub", left, right)
                 if op == TokenKind.STAR:
-                    return left * right
-                if right == 0:
-                    self._runtime_error(expr.line, expr.column, "division or modulo by zero")
+                    return runtime_arithmetic("mul", left, right)
                 if op == TokenKind.SLASH:
-                    return left // right
-                return left % right
-
-            if op in (TokenKind.LT, TokenKind.LTE, TokenKind.GT, TokenKind.GTE):
-                if not self._is_int(left) or not self._is_int(right):
-                    self._runtime_error(expr.line, expr.column, "comparison operators require int operands")
+                    return runtime_arithmetic("div", left, right)
+                if op == TokenKind.PERCENT:
+                    return runtime_arithmetic("mod", left, right)
                 if op == TokenKind.LT:
-                    return left < right
+                    return runtime_compare("lt", left, right)
                 if op == TokenKind.LTE:
-                    return left <= right
+                    return runtime_compare("lte", left, right)
                 if op == TokenKind.GT:
-                    return left > right
-                return left >= right
-
-            if op in (TokenKind.EQEQ, TokenKind.NEQ):
-                if type(left) is not type(right):
-                    self._runtime_error(expr.line, expr.column, "equality operators require matching types")
+                    return runtime_compare("gt", left, right)
+                if op == TokenKind.GTE:
+                    return runtime_compare("gte", left, right)
                 if op == TokenKind.EQEQ:
-                    return left == right
-                return left != right
-
-            self._runtime_error(expr.line, expr.column, "unsupported binary operator")
+                    return runtime_equal("eq", left, right)
+                if op == TokenKind.NEQ:
+                    return runtime_equal("neq", left, right)
+                self._runtime_error(expr.line, expr.column, "unsupported binary operator")
+            except RuntimeValueError as err:
+                self._runtime_error(expr.line, expr.column, err.message)
 
         if isinstance(expr, Call):
             if not isinstance(expr.callee, Identifier) or expr.callee.name != "print":
@@ -321,19 +332,12 @@ class Interpreter:
                 expr.arguments[0].line,
                 expr.arguments[0].column,
             )
-            self.stdout_lines.append(self._format_value(value))
-            return _VOID
+            self.stdout_lines.append(format_runtime_value(value))
+            return VOID
 
         self._runtime_error(expr.line, expr.column, "unsupported expression")
 
-    def _format_value(self, value: RuntimeValue) -> str:
-        if isinstance(value, bool):
-            return "true" if value else "false"
-        if isinstance(value, int):
-            return str(value)
-        return value
-
-    def _declare(self, name: str, value: RuntimeValue | object, is_const: bool, line: int, column: int) -> None:
+    def _declare(self, name: str, value: StackValue, is_const: bool, line: int, column: int) -> None:
         scope = self.scopes[-1]
         if name in scope:
             self._runtime_error(line, column, f"redeclaration of '{name}' in same scope")
@@ -349,9 +353,9 @@ class Interpreter:
         binding = self._resolve(name)
         if binding is None:
             self._runtime_error(line, column, f"undeclared variable '{name}'")
-        if binding.value is _UNINITIALIZED:
+        if binding.value is UNINITIALIZED:
             self._runtime_error(line, column, f"variable '{name}' is uninitialized")
-        return binding.value  # type: ignore[return-value]
+        return self._require_runtime_value(binding.value, line, column)
 
     def _assign(self, name: str, value: RuntimeValue, line: int, column: int) -> None:
         binding = self._resolve(name)
@@ -370,13 +374,14 @@ class Interpreter:
     def _runtime_error(self, line: int, column: int, message: str) -> None:
         raise RuntimeFault(message=message, line=line, column=column)
 
-    def _is_int(self, value: RuntimeValue) -> bool:
-        return isinstance(value, int) and not isinstance(value, bool)
-
     def _require_runtime_value(self, value: EvalValue, line: int, column: int) -> RuntimeValue:
-        if value is _VOID:
-            self._runtime_error(line, column, "expression does not produce a value")
-        return value  # type: ignore[return-value]
+        try:
+            resolved = require_runtime_value(value)
+        except RuntimeValueError as err:
+            self._runtime_error(line, column, err.message)
+        if not isinstance(resolved, (SemeInt, SemeBool, SemeString)):
+            self._runtime_error(line, column, "invalid runtime value")
+        return resolved
 
 
 def eval_program(program: Program) -> tuple[list[str], list[Diagnostic]]:

--- a/src/seme/pipeline.py
+++ b/src/seme/pipeline.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from typing import Literal
+
+from seme.compiler import compile_program
 from seme.diagnostics import Diagnostic
 from seme.interpreter import eval_program
 from seme.lexer import lex
 from seme.parser import parse
 from seme.typechecker import check_types
+from seme.vm import execute_chunk
+
+ExecutionBackend = Literal["vm", "interpreter"]
 
 
 def run_check(source: str) -> list[Diagnostic]:
@@ -17,7 +23,7 @@ def run_check(source: str) -> list[Diagnostic]:
     return check_types(program)
 
 
-def run_execute(source: str) -> tuple[str, list[Diagnostic]]:
+def run_execute(source: str, backend: ExecutionBackend = "vm") -> tuple[str, list[Diagnostic]]:
     tokens, lex_diags = lex(source)
     if lex_diags:
         return "", lex_diags
@@ -30,7 +36,14 @@ def run_execute(source: str) -> tuple[str, list[Diagnostic]]:
     if type_diags:
         return "", type_diags
 
-    stdout_lines, runtime_diags = eval_program(program)
+    if backend == "vm":
+        chunk = compile_program(program)
+        stdout_lines, runtime_diags = execute_chunk(chunk)
+    elif backend == "interpreter":
+        stdout_lines, runtime_diags = eval_program(program)
+    else:  # pragma: no cover
+        raise ValueError(f"Unsupported execution backend: {backend}")
+
     stdout_text = ""
     if stdout_lines:
         stdout_text = "\n".join(stdout_lines) + "\n"

--- a/src/seme/pipeline.py
+++ b/src/seme/pipeline.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from typing import Literal
 
+from seme.bytecode_cache import BytecodeCache
 from seme.compiler import compile_program
 from seme.diagnostics import Diagnostic
 from seme.interpreter import eval_program
@@ -11,6 +13,7 @@ from seme.typechecker import check_types
 from seme.vm import execute_chunk
 
 ExecutionBackend = Literal["vm", "interpreter"]
+COMPILER_VERSION = "bytecode-cache-v1"
 
 
 def run_check(source: str) -> list[Diagnostic]:
@@ -23,7 +26,12 @@ def run_check(source: str) -> list[Diagnostic]:
     return check_types(program)
 
 
-def run_execute(source: str, backend: ExecutionBackend = "vm") -> tuple[str, list[Diagnostic]]:
+def run_execute(
+    source: str,
+    backend: ExecutionBackend = "vm",
+    *,
+    cache: BytecodeCache | None = None,
+) -> tuple[str, list[Diagnostic]]:
     tokens, lex_diags = lex(source)
     if lex_diags:
         return "", lex_diags
@@ -37,7 +45,15 @@ def run_execute(source: str, backend: ExecutionBackend = "vm") -> tuple[str, lis
         return "", type_diags
 
     if backend == "vm":
-        chunk = compile_program(program)
+        if cache is not None:
+            source_hash = sha256(source.encode("utf-8")).hexdigest()
+            chunk = cache.get_or_build(
+                source_hash=source_hash,
+                compiler_version=COMPILER_VERSION,
+                build=lambda: compile_program(program),
+            )
+        else:
+            chunk = compile_program(program)
         stdout_lines, runtime_diags = execute_chunk(chunk)
     elif backend == "interpreter":
         stdout_lines, runtime_diags = eval_program(program)

--- a/src/seme/runtime.py
+++ b/src/seme/runtime.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class SemeInt:
+    value: int
+
+
+@dataclass(frozen=True)
+class SemeBool:
+    value: bool
+
+
+@dataclass(frozen=True)
+class SemeString:
+    value: str
+
+
+@dataclass(frozen=True)
+class RuntimeSentinel:
+    name: str
+
+
+@dataclass(frozen=True)
+class RuntimeValueError(Exception):
+    message: str
+
+
+RuntimeValue = SemeInt | SemeBool | SemeString
+StackValue = RuntimeValue | RuntimeSentinel
+
+UNINITIALIZED = RuntimeSentinel("uninitialized")
+VOID = RuntimeSentinel("void")
+
+
+def make_runtime_value(value: int | bool | str) -> RuntimeValue:
+    if isinstance(value, bool):
+        return SemeBool(value)
+    if isinstance(value, int):
+        return SemeInt(value)
+    return SemeString(value)
+
+
+def is_runtime_value(value: object) -> bool:
+    return isinstance(value, (SemeInt, SemeBool, SemeString))
+
+
+def is_uninitialized(value: object) -> bool:
+    return value is UNINITIALIZED
+
+
+def is_void(value: object) -> bool:
+    return value is VOID
+
+
+def is_int_value(value: RuntimeValue) -> bool:
+    return isinstance(value, SemeInt)
+
+
+def is_bool_value(value: RuntimeValue) -> bool:
+    return isinstance(value, SemeBool)
+
+
+def is_string_value(value: RuntimeValue) -> bool:
+    return isinstance(value, SemeString)
+
+
+def same_runtime_type(left: RuntimeValue, right: RuntimeValue) -> bool:
+    return type(left) is type(right)
+
+
+def format_runtime_value(value: RuntimeValue) -> str:
+    if isinstance(value, SemeBool):
+        return "true" if value.value else "false"
+    return str(value.value)
+
+
+def runtime_raw_value(value: RuntimeValue) -> int | bool | str:
+    return value.value
+
+
+def require_runtime_value(value: StackValue) -> RuntimeValue:
+    if value is VOID:
+        raise RuntimeValueError("expression does not produce a value")
+    if value is UNINITIALIZED:
+        raise RuntimeValueError("uninitialized value used in expression")
+    if not is_runtime_value(value):
+        raise RuntimeValueError("invalid runtime value")
+    return value
+
+
+def expect_bool(value: RuntimeValue, message: str) -> bool:
+    if not is_bool_value(value):
+        raise RuntimeValueError(message)
+    return value.value
+
+
+def expect_int(value: RuntimeValue, message: str) -> int:
+    if not is_int_value(value):
+        raise RuntimeValueError(message)
+    return value.value
+
+
+def expect_string(value: RuntimeValue, message: str) -> str:
+    if not is_string_value(value):
+        raise RuntimeValueError(message)
+    return value.value
+
+
+def runtime_negate(operand: RuntimeValue) -> SemeInt:
+    return SemeInt(-expect_int(operand, "unary '-' requires int operand"))
+
+
+def runtime_not(operand: RuntimeValue) -> SemeBool:
+    return SemeBool(not expect_bool(operand, "operator '!' requires bool operand"))
+
+
+def runtime_arithmetic(
+    operator: Literal["add", "sub", "mul", "div", "mod"],
+    left: RuntimeValue,
+    right: RuntimeValue,
+) -> SemeInt:
+    left_raw = expect_int(left, "arithmetic operators require int operands")
+    right_raw = expect_int(right, "arithmetic operators require int operands")
+    if operator == "add":
+        return SemeInt(left_raw + right_raw)
+    if operator == "sub":
+        return SemeInt(left_raw - right_raw)
+    if operator == "mul":
+        return SemeInt(left_raw * right_raw)
+    if right_raw == 0:
+        raise RuntimeValueError("division or modulo by zero")
+    if operator == "div":
+        return SemeInt(left_raw // right_raw)
+    return SemeInt(left_raw % right_raw)
+
+
+def runtime_compare(
+    operator: Literal["lt", "lte", "gt", "gte"],
+    left: RuntimeValue,
+    right: RuntimeValue,
+) -> SemeBool:
+    left_raw = expect_int(left, "comparison operators require int operands")
+    right_raw = expect_int(right, "comparison operators require int operands")
+    if operator == "lt":
+        return SemeBool(left_raw < right_raw)
+    if operator == "lte":
+        return SemeBool(left_raw <= right_raw)
+    if operator == "gt":
+        return SemeBool(left_raw > right_raw)
+    return SemeBool(left_raw >= right_raw)
+
+
+def runtime_equal(operator: Literal["eq", "neq"], left: RuntimeValue, right: RuntimeValue) -> SemeBool:
+    if not same_runtime_type(left, right):
+        raise RuntimeValueError("equality operators require matching types")
+    result = runtime_raw_value(left) == runtime_raw_value(right)
+    if operator == "neq":
+        result = not result
+    return SemeBool(result)
+
+
+__all__ = [
+    "RuntimeSentinel",
+    "RuntimeValueError",
+    "RuntimeValue",
+    "SemeBool",
+    "SemeInt",
+    "SemeString",
+    "StackValue",
+    "UNINITIALIZED",
+    "VOID",
+    "expect_bool",
+    "expect_int",
+    "expect_string",
+    "format_runtime_value",
+    "is_bool_value",
+    "is_int_value",
+    "is_runtime_value",
+    "is_string_value",
+    "is_uninitialized",
+    "is_void",
+    "make_runtime_value",
+    "require_runtime_value",
+    "runtime_arithmetic",
+    "runtime_compare",
+    "runtime_equal",
+    "runtime_negate",
+    "runtime_not",
+    "runtime_raw_value",
+    "same_runtime_type",
+]

--- a/src/seme/runtime.py
+++ b/src/seme/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from collections.abc import Iterable
 from typing import Literal
 
 
@@ -20,6 +21,17 @@ class SemeString:
 
 
 @dataclass(frozen=True)
+class HeapRef:
+    object_id: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class HeapString:
+    value: str
+
+
+@dataclass(frozen=True)
 class RuntimeSentinel:
     name: str
 
@@ -29,23 +41,72 @@ class RuntimeValueError(Exception):
     message: str
 
 
-RuntimeValue = SemeInt | SemeBool | SemeString
+@dataclass
+class RuntimeHeap:
+    objects: dict[int, HeapString] = field(default_factory=dict)
+    next_object_id: int = 1
+
+    def allocate_string(self, value: str) -> HeapRef:
+        object_id = self.next_object_id
+        self.next_object_id += 1
+        self.objects[object_id] = HeapString(value=value)
+        return HeapRef(object_id=object_id, kind="string")
+
+    def lookup(self, ref: HeapRef) -> HeapString:
+        if ref.kind != "string":
+            raise RuntimeValueError(f"unknown heap object kind '{ref.kind}'")
+        try:
+            return self.objects[ref.object_id]
+        except KeyError as exc:
+            raise RuntimeValueError(f"dangling heap object {ref.object_id}") from exc
+
+    def root_object_ids(self, *value_groups: Iterable[StackValue]) -> set[int]:
+        root_ids: set[int] = set()
+        for group in value_groups:
+            for value in group:
+                if isinstance(value, HeapRef):
+                    root_ids.add(value.object_id)
+        return root_ids
+
+    def tracked_object_ids(self) -> set[int]:
+        return set(self.objects)
+
+    def live_object_ids(self, *value_groups: Iterable[StackValue]) -> set[int]:
+        return self.root_object_ids(*value_groups)
+
+
+RuntimeValue = SemeInt | SemeBool | SemeString | HeapRef
 StackValue = RuntimeValue | RuntimeSentinel
 
 UNINITIALIZED = RuntimeSentinel("uninitialized")
 VOID = RuntimeSentinel("void")
 
 
-def make_runtime_value(value: int | bool | str) -> RuntimeValue:
+def allocate_string(value: str, heap: RuntimeHeap) -> HeapRef:
+    return heap.allocate_string(value)
+
+
+def root_object_ids(*value_groups: Iterable[StackValue]) -> set[int]:
+    root_ids: set[int] = set()
+    for group in value_groups:
+        for value in group:
+            if isinstance(value, HeapRef):
+                root_ids.add(value.object_id)
+    return root_ids
+
+
+def make_runtime_value(value: int | bool | str, *, heap: RuntimeHeap | None = None) -> RuntimeValue:
     if isinstance(value, bool):
         return SemeBool(value)
     if isinstance(value, int):
         return SemeInt(value)
+    if heap is not None:
+        return allocate_string(value, heap)
     return SemeString(value)
 
 
 def is_runtime_value(value: object) -> bool:
-    return isinstance(value, (SemeInt, SemeBool, SemeString))
+    return isinstance(value, (SemeInt, SemeBool, SemeString, HeapRef))
 
 
 def is_uninitialized(value: object) -> bool:
@@ -65,20 +126,28 @@ def is_bool_value(value: RuntimeValue) -> bool:
 
 
 def is_string_value(value: RuntimeValue) -> bool:
-    return isinstance(value, SemeString)
+    return isinstance(value, (SemeString, HeapRef)) and (
+        not isinstance(value, HeapRef) or value.kind == "string"
+    )
 
 
 def same_runtime_type(left: RuntimeValue, right: RuntimeValue) -> bool:
+    if is_string_value(left) and is_string_value(right):
+        return True
     return type(left) is type(right)
 
 
-def format_runtime_value(value: RuntimeValue) -> str:
+def format_runtime_value(value: RuntimeValue, *, heap: RuntimeHeap | None = None) -> str:
     if isinstance(value, SemeBool):
         return "true" if value.value else "false"
+    if isinstance(value, HeapRef):
+        return expect_string(value, "string value required", heap=heap)
     return str(value.value)
 
 
-def runtime_raw_value(value: RuntimeValue) -> int | bool | str:
+def runtime_raw_value(value: RuntimeValue, *, heap: RuntimeHeap | None = None) -> int | bool | str:
+    if isinstance(value, HeapRef):
+        return expect_string(value, "string value required", heap=heap)
     return value.value
 
 
@@ -104,8 +173,12 @@ def expect_int(value: RuntimeValue, message: str) -> int:
     return value.value
 
 
-def expect_string(value: RuntimeValue, message: str) -> str:
-    if not is_string_value(value):
+def expect_string(value: RuntimeValue, message: str, *, heap: RuntimeHeap | None = None) -> str:
+    if isinstance(value, HeapRef):
+        if heap is None:
+            raise RuntimeValueError("string heap is required")
+        return heap.lookup(value).value
+    if not isinstance(value, SemeString):
         raise RuntimeValueError(message)
     return value.value
 
@@ -154,16 +227,26 @@ def runtime_compare(
     return SemeBool(left_raw >= right_raw)
 
 
-def runtime_equal(operator: Literal["eq", "neq"], left: RuntimeValue, right: RuntimeValue) -> SemeBool:
+def runtime_equal(
+    operator: Literal["eq", "neq"],
+    left: RuntimeValue,
+    right: RuntimeValue,
+    *,
+    heap: RuntimeHeap | None = None,
+) -> SemeBool:
     if not same_runtime_type(left, right):
         raise RuntimeValueError("equality operators require matching types")
-    result = runtime_raw_value(left) == runtime_raw_value(right)
+    result = runtime_raw_value(left, heap=heap) == runtime_raw_value(right, heap=heap)
     if operator == "neq":
         result = not result
     return SemeBool(result)
 
 
 __all__ = [
+    "allocate_string",
+    "HeapRef",
+    "HeapString",
+    "RuntimeHeap",
     "RuntimeSentinel",
     "RuntimeValueError",
     "RuntimeValue",
@@ -192,4 +275,5 @@ __all__ = [
     "runtime_not",
     "runtime_raw_value",
     "same_runtime_type",
+    "root_object_ids",
 ]

--- a/src/seme/runtime_faults.py
+++ b/src/seme/runtime_faults.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from seme.diagnostics import Diagnostic
+
+
+@dataclass(frozen=True)
+class RuntimeFault(Exception):
+    message: str
+    line: int
+    column: int
+
+
+def runtime_diagnostic(message: str, line: int, column: int) -> Diagnostic:
+    return Diagnostic(
+        code="RUNTIME-001",
+        message=f"Runtime error: {message}",
+        line=line,
+        column=column,
+    )
+
+
+def diagnostic_from_runtime_fault(fault: RuntimeFault) -> Diagnostic:
+    return runtime_diagnostic(fault.message, fault.line, fault.column)
+
+
+def diagnostic_from_unexpected_runtime_error(exc: Exception, *, line: int, column: int) -> Diagnostic:
+    return runtime_diagnostic(str(exc), line, column)
+
+
+__all__ = [
+    "RuntimeFault",
+    "diagnostic_from_runtime_fault",
+    "diagnostic_from_unexpected_runtime_error",
+    "runtime_diagnostic",
+]

--- a/src/seme/source_mapping.py
+++ b/src/seme/source_mapping.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, SourceSpan
+
+
+DEFAULT_SOURCE_SPAN = SourceSpan(line=1, column=1)
+
+
+def source_span_for_offset(chunk: Chunk, offset: int) -> SourceSpan:
+    if not chunk.source_map:
+        return DEFAULT_SOURCE_SPAN
+    if offset < 0:
+        return chunk.source_map[0]
+    if offset >= len(chunk.source_map):
+        return chunk.source_map[-1]
+    return chunk.source_map[offset]
+
+
+def source_span_for_incomplete_chunk(chunk: Chunk, offset: int) -> SourceSpan:
+    try:
+        return chunk.span_for_offset(offset)
+    except IndexError:
+        return source_span_for_offset(chunk, offset)
+
+
+__all__ = [
+    "DEFAULT_SOURCE_SPAN",
+    "source_span_for_incomplete_chunk",
+    "source_span_for_offset",
+]

--- a/src/seme/vm.py
+++ b/src/seme/vm.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from time import perf_counter_ns
 
-from seme.bytecode import Chunk, OpCode
+from seme.builtins import DEFAULT_BUILTINS
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
+from seme.bytecode_validator import validate_chunk
 from seme.diagnostics import Diagnostic
 from seme.runtime import (
+    RuntimeHeap,
     RuntimeValue,
     RuntimeValueError,
-    SemeBool,
-    SemeInt,
     SemeString,
     StackValue,
     UNINITIALIZED,
     expect_bool,
-    format_runtime_value,
+    is_runtime_value,
+    make_runtime_value,
     require_runtime_value,
     runtime_arithmetic,
     runtime_compare,
@@ -21,12 +24,40 @@ from seme.runtime import (
     runtime_negate,
     runtime_not,
 )
+from seme.runtime_faults import (
+    RuntimeFault,
+    diagnostic_from_runtime_fault,
+    diagnostic_from_unexpected_runtime_error,
+)
+from seme.source_mapping import source_span_for_incomplete_chunk, source_span_for_offset
+from seme.vm_metrics import ProfilingHook, VMMetrics
+from seme.vm_trace import TraceEvent, TraceHook, TracePhase
 
 
-@dataclass(frozen=True)
-class RuntimeFault(Exception):
-    message: str
-    offset: int
+@dataclass
+class Frame:
+    locals: list[StackValue] = field(default_factory=list)
+    return_ip: int | None = None
+
+
+@dataclass
+class RuntimeState:
+    frames: list[Frame] = field(default_factory=lambda: [Frame()])
+    globals: dict[str, StackValue] = field(default_factory=dict)
+    heap: RuntimeHeap = field(default_factory=RuntimeHeap)
+
+    @property
+    def current_frame(self) -> Frame:
+        if not self.frames:
+            raise RuntimeError("runtime has no active frame")
+        return self.frames[-1]
+
+    def gc_root_values(self) -> list[StackValue]:
+        roots: list[StackValue] = []
+        for frame in self.frames:
+            roots.extend(frame.locals)
+        roots.extend(self.globals.values())
+        return roots
 
 
 @dataclass
@@ -34,49 +65,106 @@ class VirtualMachine:
     chunk: Chunk
     ip: int = 0
     stack: list[StackValue] = field(default_factory=list)
-    locals: list[StackValue] = field(default_factory=list)
+    runtime: RuntimeState = field(default_factory=RuntimeState)
     stdout_lines: list[str] = field(default_factory=list)
+    trace_hook: TraceHook | None = None
+    profiling_hook: ProfilingHook | None = None
+    metrics: VMMetrics = field(default_factory=VMMetrics)
+
+    @property
+    def locals(self) -> list[StackValue]:
+        return self.runtime.current_frame.locals
+
+    @property
+    def runtime_heap(self) -> RuntimeHeap:
+        return self.runtime.heap
+
+    def gc_root_values(self) -> list[StackValue]:
+        roots = list(self.stack)
+        roots.extend(self.runtime.gc_root_values())
+        roots.extend(self.chunk.constants)
+        return roots
+
+    def write_stdout_line(self, line: str) -> None:
+        self.stdout_lines.append(line)
 
     def execute(self) -> tuple[list[str], list[Diagnostic]]:
         start_index = len(self.stdout_lines)
         diagnostics: list[Diagnostic] = []
+        validation_diags = validate_chunk(self.chunk)
+        if validation_diags:
+            return self.stdout_lines[start_index:], validation_diags
+        self.metrics = VMMetrics()
+        started = True
+        start_ns = perf_counter_ns()
         try:
             while self.ip < len(self.chunk.instructions):
                 instruction = self.chunk.instructions[self.ip]
+                offset = self.ip
                 self.ip += 1
-                self._dispatch(instruction.opcode, instruction.operands)
+                span = source_span_for_offset(self.chunk, offset)
+                self._record_instruction(instruction.opcode.value)
+                self._emit_trace(TracePhase.BEFORE, offset, instruction, span)
+                try:
+                    self._dispatch(instruction.opcode, instruction.operands)
+                except RuntimeFault:
+                    self.metrics.runtime_error_count += 1
+                    self._emit_trace(TracePhase.ERROR, offset, instruction, span)
+                    raise
+                self._record_peaks()
+                self._emit_trace(TracePhase.AFTER, offset, instruction, span)
             return self.stdout_lines[start_index:], diagnostics
         except RuntimeFault as err:
-            span = self.chunk.span_for_offset(err.offset)
-            diagnostics.append(
-                Diagnostic(
-                    code="RUNTIME-001",
-                    message=f"Runtime error: {err.message}",
-                    line=span.line,
-                    column=span.column,
-                )
-            )
+            diagnostics.append(diagnostic_from_runtime_fault(err))
             return self.stdout_lines[start_index:], diagnostics
         except Exception as exc:  # pragma: no cover
-            span = self.chunk.span_for_offset(min(self.ip, len(self.chunk.instructions) - 1)) if self.chunk.instructions else None
+            span = source_span_for_incomplete_chunk(
+                self.chunk,
+                min(self.ip, len(self.chunk.instructions) - 1),
+            ) if self.chunk.instructions else None
+            if span is not None and self.ip > 0:
+                instruction = self.chunk.instructions[self.ip - 1]
+                self._emit_trace(TracePhase.ERROR, self.ip - 1, instruction, span)
             diagnostics.append(
-                Diagnostic(
-                    code="RUNTIME-001",
-                    message=f"Runtime error: {exc}",
+                diagnostic_from_unexpected_runtime_error(
+                    exc,
                     line=span.line if span else 1,
                     column=span.column if span else 1,
                 )
             )
             return self.stdout_lines[start_index:], diagnostics
+        finally:
+            if started:
+                self.metrics.wall_time_ns = perf_counter_ns() - start_ns
+                if self.profiling_hook is not None:
+                    self.profiling_hook(self.metrics)
 
     def _dispatch(self, opcode: OpCode, operands: tuple[int, ...]) -> None:
         current_offset = self.ip - 1
 
         if opcode == OpCode.LOAD_CONST:
-            self.stack.append(self.chunk.constants[operands[0]])
+            constant = self.chunk.constants[operands[0]]
+            if isinstance(constant, SemeString):
+                self.stack.append(make_runtime_value(constant.value, heap=self.runtime.heap))
+            else:
+                self.stack.append(constant)
             return
         if opcode == OpCode.LOAD_UNINITIALIZED:
             self.stack.append(UNINITIALIZED)
+            return
+        if opcode == OpCode.LOAD_GLOBAL:
+            name = self._global_name(operands[0], current_offset)
+            self.stack.append(self._read_global(name, current_offset))
+            return
+        if opcode == OpCode.DEFINE_GLOBAL:
+            name = self._global_name(operands[0], current_offset)
+            value = self._peek(current_offset)
+            self.runtime.globals[name] = value
+            return
+        if opcode == OpCode.STORE_GLOBAL:
+            name = self._global_name(operands[0], current_offset)
+            value = self._peek(current_offset)
+            self._write_global(name, value, current_offset)
             return
         if opcode == OpCode.LOAD_LOCAL:
             slot = operands[0]
@@ -93,9 +181,10 @@ class VirtualMachine:
             return
         if opcode == OpCode.POP_N:
             count = operands[0]
-            if count > len(self.locals):
+            frame = self.runtime.current_frame
+            if count > len(frame.locals):
                 self._fault("local cleanup underflow", current_offset)
-            del self.locals[-count:]
+            del frame.locals[-count:]
             return
         if opcode in (OpCode.ADD, OpCode.SUB, OpCode.MUL, OpCode.DIV, OpCode.MOD):
             right = self._pop_runtime(current_offset)
@@ -135,7 +224,14 @@ class VirtualMachine:
             right = self._pop_runtime(current_offset)
             left = self._pop_runtime(current_offset)
             try:
-                self.stack.append(runtime_equal("eq" if opcode == OpCode.EQUAL else "neq", left, right))
+                self.stack.append(
+                    runtime_equal(
+                        "eq" if opcode == OpCode.EQUAL else "neq",
+                        left,
+                        right,
+                        heap=self.runtime.heap,
+                    )
+                )
             except RuntimeValueError as err:
                 self._fault(err.message, current_offset)
             return
@@ -168,7 +264,10 @@ class VirtualMachine:
             return
         if opcode == OpCode.PRINT:
             value = self._pop_runtime(current_offset)
-            self.stdout_lines.append(format_runtime_value(value))
+            try:
+                DEFAULT_BUILTINS.invoke("print", [value], self)
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode == OpCode.RETURN:
             self.ip = len(self.chunk.instructions)
@@ -177,19 +276,36 @@ class VirtualMachine:
         self._fault(f"unsupported opcode {opcode}", current_offset)
 
     def _read_local(self, slot: int, offset: int) -> RuntimeValue:
-        if slot >= len(self.locals):
+        frame = self.runtime.current_frame
+        if slot >= len(frame.locals):
             self._fault(f"invalid local slot {slot}", offset)
-        value = self.locals[slot]
+        value = frame.locals[slot]
         if value is UNINITIALIZED:
             self._fault(f"variable in slot {slot} is uninitialized", offset)
-        if not isinstance(value, (SemeInt, SemeBool, SemeString)):
+        if not is_runtime_value(value):
             self._fault(f"invalid runtime value in slot {slot}", offset)
         return value
 
+    def _read_global(self, name: str, offset: int) -> RuntimeValue:
+        if name not in self.runtime.globals:
+            self._fault(f"undeclared variable '{name}'", offset)
+        value = self.runtime.globals[name]
+        if value is UNINITIALIZED:
+            self._fault(f"variable '{name}' is uninitialized", offset)
+        if not is_runtime_value(value):
+            self._fault(f"invalid runtime value in global '{name}'", offset)
+        return value
+
     def _write_local(self, slot: int, value: StackValue, offset: int) -> None:
-        while len(self.locals) <= slot:
-            self.locals.append(UNINITIALIZED)
-        self.locals[slot] = value
+        frame = self.runtime.current_frame
+        while len(frame.locals) <= slot:
+            frame.locals.append(UNINITIALIZED)
+        frame.locals[slot] = value
+
+    def _write_global(self, name: str, value: StackValue, offset: int) -> None:
+        if name not in self.runtime.globals:
+            self._fault(f"undeclared variable '{name}'", offset)
+        self.runtime.globals[name] = value
 
     def _peek(self, offset: int) -> StackValue:
         if not self.stack:
@@ -216,7 +332,44 @@ class VirtualMachine:
             self._fault(err.message, offset)
 
     def _fault(self, message: str, offset: int) -> None:
-        raise RuntimeFault(message=message, offset=offset)
+        span = source_span_for_offset(self.chunk, offset)
+        raise RuntimeFault(message=message, line=span.line, column=span.column)
+
+    def _global_name(self, const_index: int, offset: int) -> str:
+        if const_index >= len(self.chunk.constants):
+            self._fault(f"invalid global name constant {const_index}", offset)
+        value = self.chunk.constants[const_index]
+        if not isinstance(value, SemeString):
+            self._fault(f"invalid global name constant {const_index}", offset)
+        return value.value
+
+    def _emit_trace(
+        self,
+        phase: TracePhase,
+        offset: int,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> None:
+        if self.trace_hook is None:
+            return
+        event = TraceEvent(
+            phase=phase,
+            offset=offset,
+            instruction=instruction,
+            span=span,
+            stack_depth=len(self.stack),
+            frame_depth=len(self.runtime.frames),
+        )
+        self.trace_hook(event)
+
+    def _record_instruction(self, opcode_name: str) -> None:
+        self.metrics.instruction_count += 1
+        self.metrics.opcode_counts[opcode_name] = self.metrics.opcode_counts.get(opcode_name, 0) + 1
+        self._record_peaks()
+
+    def _record_peaks(self) -> None:
+        self.metrics.max_stack_depth = max(self.metrics.max_stack_depth, len(self.stack))
+        self.metrics.max_frame_depth = max(self.metrics.max_frame_depth, len(self.runtime.frames))
 
 
 def execute_chunk(chunk: Chunk) -> tuple[list[str], list[Diagnostic]]:
@@ -224,6 +377,8 @@ def execute_chunk(chunk: Chunk) -> tuple[list[str], list[Diagnostic]]:
 
 
 __all__ = [
+    "Frame",
+    "RuntimeState",
     "VirtualMachine",
     "execute_chunk",
 ]

--- a/src/seme/vm.py
+++ b/src/seme/vm.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from seme.bytecode import Chunk, OpCode
+from seme.diagnostics import Diagnostic
+
+RuntimeValue = int | bool | str
+StackValue = RuntimeValue | object
+_UNINITIALIZED = object()
+
+
+@dataclass(frozen=True)
+class RuntimeFault(Exception):
+    message: str
+    offset: int
+
+
+@dataclass
+class VirtualMachine:
+    chunk: Chunk
+    ip: int = 0
+    stack: list[StackValue] = field(default_factory=list)
+    locals: list[StackValue] = field(default_factory=list)
+    stdout_lines: list[str] = field(default_factory=list)
+
+    def execute(self) -> tuple[list[str], list[Diagnostic]]:
+        start_index = len(self.stdout_lines)
+        diagnostics: list[Diagnostic] = []
+        try:
+            while self.ip < len(self.chunk.instructions):
+                instruction = self.chunk.instructions[self.ip]
+                self.ip += 1
+                self._dispatch(instruction.opcode, instruction.operands)
+            return self.stdout_lines[start_index:], diagnostics
+        except RuntimeFault as err:
+            span = self.chunk.span_for_offset(err.offset)
+            diagnostics.append(
+                Diagnostic(
+                    code="RUNTIME-001",
+                    message=f"Runtime error: {err.message}",
+                    line=span.line,
+                    column=span.column,
+                )
+            )
+            return self.stdout_lines[start_index:], diagnostics
+        except Exception as exc:  # pragma: no cover
+            span = self.chunk.span_for_offset(min(self.ip, len(self.chunk.instructions) - 1)) if self.chunk.instructions else None
+            diagnostics.append(
+                Diagnostic(
+                    code="RUNTIME-001",
+                    message=f"Runtime error: {exc}",
+                    line=span.line if span else 1,
+                    column=span.column if span else 1,
+                )
+            )
+            return self.stdout_lines[start_index:], diagnostics
+
+    def _dispatch(self, opcode: OpCode, operands: tuple[int, ...]) -> None:
+        current_offset = self.ip - 1
+
+        if opcode == OpCode.LOAD_CONST:
+            self.stack.append(self.chunk.constants[operands[0]])
+            return
+        if opcode == OpCode.LOAD_UNINITIALIZED:
+            self.stack.append(_UNINITIALIZED)
+            return
+        if opcode == OpCode.LOAD_LOCAL:
+            slot = operands[0]
+            value = self._read_local(slot, current_offset)
+            self.stack.append(value)
+            return
+        if opcode == OpCode.STORE_LOCAL:
+            slot = operands[0]
+            value = self._peek(current_offset)
+            self._write_local(slot, value, current_offset)
+            return
+        if opcode == OpCode.POP:
+            self._pop(current_offset)
+            return
+        if opcode == OpCode.POP_N:
+            count = operands[0]
+            if count > len(self.locals):
+                self._fault("local cleanup underflow", current_offset)
+            del self.locals[-count:]
+            return
+        if opcode in (OpCode.ADD, OpCode.SUB, OpCode.MUL, OpCode.DIV, OpCode.MOD):
+            right = self._pop_runtime(current_offset)
+            left = self._pop_runtime(current_offset)
+            if not self._is_int(left) or not self._is_int(right):
+                self._fault("arithmetic operators require int operands", current_offset)
+            if opcode == OpCode.ADD:
+                self.stack.append(left + right)
+                return
+            if opcode == OpCode.SUB:
+                self.stack.append(left - right)
+                return
+            if opcode == OpCode.MUL:
+                self.stack.append(left * right)
+                return
+            if right == 0:
+                self._fault("division or modulo by zero", current_offset)
+            if opcode == OpCode.DIV:
+                self.stack.append(left // right)
+                return
+            self.stack.append(left % right)
+            return
+        if opcode == OpCode.NEGATE:
+            operand = self._pop_runtime(current_offset)
+            if not self._is_int(operand):
+                self._fault("unary '-' requires int operand", current_offset)
+            self.stack.append(-operand)
+            return
+        if opcode == OpCode.NOT:
+            operand = self._pop_runtime(current_offset)
+            if not isinstance(operand, bool):
+                self._fault("operator '!' requires bool operand", current_offset)
+            self.stack.append(not operand)
+            return
+        if opcode in (OpCode.EQUAL, OpCode.NOT_EQUAL):
+            right = self._pop_runtime(current_offset)
+            left = self._pop_runtime(current_offset)
+            if type(left) is not type(right):
+                self._fault("equality operators require matching types", current_offset)
+            self.stack.append(left == right if opcode == OpCode.EQUAL else left != right)
+            return
+        if opcode in (OpCode.LESS, OpCode.LESS_EQUAL, OpCode.GREATER, OpCode.GREATER_EQUAL):
+            right = self._pop_runtime(current_offset)
+            left = self._pop_runtime(current_offset)
+            if not self._is_int(left) or not self._is_int(right):
+                self._fault("comparison operators require int operands", current_offset)
+            if opcode == OpCode.LESS:
+                self.stack.append(left < right)
+            elif opcode == OpCode.LESS_EQUAL:
+                self.stack.append(left <= right)
+            elif opcode == OpCode.GREATER:
+                self.stack.append(left > right)
+            else:
+                self.stack.append(left >= right)
+            return
+        if opcode == OpCode.JUMP:
+            self.ip = operands[0]
+            return
+        if opcode == OpCode.JUMP_IF_FALSE:
+            value = self._peek_runtime(current_offset)
+            if not isinstance(value, bool):
+                self._fault("condition must evaluate to bool", current_offset)
+            if not value:
+                self.ip = operands[0]
+            return
+        if opcode == OpCode.PRINT:
+            value = self._pop_runtime(current_offset)
+            self.stdout_lines.append(self._format_value(value))
+            return
+        if opcode == OpCode.RETURN:
+            self.ip = len(self.chunk.instructions)
+            return
+
+        self._fault(f"unsupported opcode {opcode}", current_offset)
+
+    def _read_local(self, slot: int, offset: int) -> RuntimeValue:
+        if slot >= len(self.locals):
+            self._fault(f"invalid local slot {slot}", offset)
+        value = self.locals[slot]
+        if value is _UNINITIALIZED:
+            self._fault(f"variable in slot {slot} is uninitialized", offset)
+        if not isinstance(value, (int, bool, str)):
+            self._fault(f"invalid runtime value in slot {slot}", offset)
+        return value
+
+    def _write_local(self, slot: int, value: StackValue, offset: int) -> None:
+        while len(self.locals) <= slot:
+            self.locals.append(_UNINITIALIZED)
+        self.locals[slot] = value
+
+    def _peek(self, offset: int) -> StackValue:
+        if not self.stack:
+            self._fault("stack underflow", offset)
+        return self.stack[-1]
+
+    def _peek_runtime(self, offset: int) -> RuntimeValue:
+        value = self._peek(offset)
+        if value is _UNINITIALIZED:
+            self._fault("uninitialized value used in expression", offset)
+        if not isinstance(value, (int, bool, str)):
+            self._fault("invalid runtime value on stack", offset)
+        return value
+
+    def _pop(self, offset: int) -> StackValue:
+        if not self.stack:
+            self._fault("stack underflow", offset)
+        return self.stack.pop()
+
+    def _pop_runtime(self, offset: int) -> RuntimeValue:
+        value = self._pop(offset)
+        if value is _UNINITIALIZED:
+            self._fault("uninitialized value used in expression", offset)
+        if not isinstance(value, (int, bool, str)):
+            self._fault("invalid runtime value on stack", offset)
+        return value
+
+    def _fault(self, message: str, offset: int) -> None:
+        raise RuntimeFault(message=message, offset=offset)
+
+    def _format_value(self, value: RuntimeValue) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _is_int(self, value: RuntimeValue) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool)
+
+
+def execute_chunk(chunk: Chunk) -> tuple[list[str], list[Diagnostic]]:
+    return VirtualMachine(chunk).execute()
+
+
+__all__ = [
+    "VirtualMachine",
+    "execute_chunk",
+]

--- a/src/seme/vm.py
+++ b/src/seme/vm.py
@@ -4,10 +4,23 @@ from dataclasses import dataclass, field
 
 from seme.bytecode import Chunk, OpCode
 from seme.diagnostics import Diagnostic
-
-RuntimeValue = int | bool | str
-StackValue = RuntimeValue | object
-_UNINITIALIZED = object()
+from seme.runtime import (
+    RuntimeValue,
+    RuntimeValueError,
+    SemeBool,
+    SemeInt,
+    SemeString,
+    StackValue,
+    UNINITIALIZED,
+    expect_bool,
+    format_runtime_value,
+    require_runtime_value,
+    runtime_arithmetic,
+    runtime_compare,
+    runtime_equal,
+    runtime_negate,
+    runtime_not,
+)
 
 
 @dataclass(frozen=True)
@@ -63,7 +76,7 @@ class VirtualMachine:
             self.stack.append(self.chunk.constants[operands[0]])
             return
         if opcode == OpCode.LOAD_UNINITIALIZED:
-            self.stack.append(_UNINITIALIZED)
+            self.stack.append(UNINITIALIZED)
             return
         if opcode == OpCode.LOAD_LOCAL:
             slot = operands[0]
@@ -87,70 +100,75 @@ class VirtualMachine:
         if opcode in (OpCode.ADD, OpCode.SUB, OpCode.MUL, OpCode.DIV, OpCode.MOD):
             right = self._pop_runtime(current_offset)
             left = self._pop_runtime(current_offset)
-            if not self._is_int(left) or not self._is_int(right):
-                self._fault("arithmetic operators require int operands", current_offset)
-            if opcode == OpCode.ADD:
-                self.stack.append(left + right)
-                return
-            if opcode == OpCode.SUB:
-                self.stack.append(left - right)
-                return
-            if opcode == OpCode.MUL:
-                self.stack.append(left * right)
-                return
-            if right == 0:
-                self._fault("division or modulo by zero", current_offset)
-            if opcode == OpCode.DIV:
-                self.stack.append(left // right)
-                return
-            self.stack.append(left % right)
+            try:
+                if opcode == OpCode.ADD:
+                    self.stack.append(runtime_arithmetic("add", left, right))
+                    return
+                if opcode == OpCode.SUB:
+                    self.stack.append(runtime_arithmetic("sub", left, right))
+                    return
+                if opcode == OpCode.MUL:
+                    self.stack.append(runtime_arithmetic("mul", left, right))
+                    return
+                if opcode == OpCode.DIV:
+                    self.stack.append(runtime_arithmetic("div", left, right))
+                    return
+                self.stack.append(runtime_arithmetic("mod", left, right))
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode == OpCode.NEGATE:
             operand = self._pop_runtime(current_offset)
-            if not self._is_int(operand):
-                self._fault("unary '-' requires int operand", current_offset)
-            self.stack.append(-operand)
+            try:
+                self.stack.append(runtime_negate(operand))
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode == OpCode.NOT:
             operand = self._pop_runtime(current_offset)
-            if not isinstance(operand, bool):
-                self._fault("operator '!' requires bool operand", current_offset)
-            self.stack.append(not operand)
+            try:
+                self.stack.append(runtime_not(operand))
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode in (OpCode.EQUAL, OpCode.NOT_EQUAL):
             right = self._pop_runtime(current_offset)
             left = self._pop_runtime(current_offset)
-            if type(left) is not type(right):
-                self._fault("equality operators require matching types", current_offset)
-            self.stack.append(left == right if opcode == OpCode.EQUAL else left != right)
+            try:
+                self.stack.append(runtime_equal("eq" if opcode == OpCode.EQUAL else "neq", left, right))
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode in (OpCode.LESS, OpCode.LESS_EQUAL, OpCode.GREATER, OpCode.GREATER_EQUAL):
             right = self._pop_runtime(current_offset)
             left = self._pop_runtime(current_offset)
-            if not self._is_int(left) or not self._is_int(right):
-                self._fault("comparison operators require int operands", current_offset)
-            if opcode == OpCode.LESS:
-                self.stack.append(left < right)
-            elif opcode == OpCode.LESS_EQUAL:
-                self.stack.append(left <= right)
-            elif opcode == OpCode.GREATER:
-                self.stack.append(left > right)
-            else:
-                self.stack.append(left >= right)
+            try:
+                if opcode == OpCode.LESS:
+                    self.stack.append(runtime_compare("lt", left, right))
+                elif opcode == OpCode.LESS_EQUAL:
+                    self.stack.append(runtime_compare("lte", left, right))
+                elif opcode == OpCode.GREATER:
+                    self.stack.append(runtime_compare("gt", left, right))
+                else:
+                    self.stack.append(runtime_compare("gte", left, right))
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
             return
         if opcode == OpCode.JUMP:
             self.ip = operands[0]
             return
         if opcode == OpCode.JUMP_IF_FALSE:
             value = self._peek_runtime(current_offset)
-            if not isinstance(value, bool):
-                self._fault("condition must evaluate to bool", current_offset)
-            if not value:
+            try:
+                condition = expect_bool(value, "condition must evaluate to bool")
+            except RuntimeValueError as err:
+                self._fault(err.message, current_offset)
+            if not condition:
                 self.ip = operands[0]
             return
         if opcode == OpCode.PRINT:
             value = self._pop_runtime(current_offset)
-            self.stdout_lines.append(self._format_value(value))
+            self.stdout_lines.append(format_runtime_value(value))
             return
         if opcode == OpCode.RETURN:
             self.ip = len(self.chunk.instructions)
@@ -162,15 +180,15 @@ class VirtualMachine:
         if slot >= len(self.locals):
             self._fault(f"invalid local slot {slot}", offset)
         value = self.locals[slot]
-        if value is _UNINITIALIZED:
+        if value is UNINITIALIZED:
             self._fault(f"variable in slot {slot} is uninitialized", offset)
-        if not isinstance(value, (int, bool, str)):
+        if not isinstance(value, (SemeInt, SemeBool, SemeString)):
             self._fault(f"invalid runtime value in slot {slot}", offset)
         return value
 
     def _write_local(self, slot: int, value: StackValue, offset: int) -> None:
         while len(self.locals) <= slot:
-            self.locals.append(_UNINITIALIZED)
+            self.locals.append(UNINITIALIZED)
         self.locals[slot] = value
 
     def _peek(self, offset: int) -> StackValue:
@@ -180,11 +198,10 @@ class VirtualMachine:
 
     def _peek_runtime(self, offset: int) -> RuntimeValue:
         value = self._peek(offset)
-        if value is _UNINITIALIZED:
-            self._fault("uninitialized value used in expression", offset)
-        if not isinstance(value, (int, bool, str)):
-            self._fault("invalid runtime value on stack", offset)
-        return value
+        try:
+            return require_runtime_value(value)
+        except RuntimeValueError as err:
+            self._fault(err.message, offset)
 
     def _pop(self, offset: int) -> StackValue:
         if not self.stack:
@@ -193,22 +210,13 @@ class VirtualMachine:
 
     def _pop_runtime(self, offset: int) -> RuntimeValue:
         value = self._pop(offset)
-        if value is _UNINITIALIZED:
-            self._fault("uninitialized value used in expression", offset)
-        if not isinstance(value, (int, bool, str)):
-            self._fault("invalid runtime value on stack", offset)
-        return value
+        try:
+            return require_runtime_value(value)
+        except RuntimeValueError as err:
+            self._fault(err.message, offset)
 
     def _fault(self, message: str, offset: int) -> None:
         raise RuntimeFault(message=message, offset=offset)
-
-    def _format_value(self, value: RuntimeValue) -> str:
-        if isinstance(value, bool):
-            return "true" if value else "false"
-        return str(value)
-
-    def _is_int(self, value: RuntimeValue) -> bool:
-        return isinstance(value, int) and not isinstance(value, bool)
 
 
 def execute_chunk(chunk: Chunk) -> tuple[list[str], list[Diagnostic]]:

--- a/src/seme/vm_metrics.py
+++ b/src/seme/vm_metrics.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass
+class VMMetrics:
+    instruction_count: int = 0
+    max_stack_depth: int = 0
+    max_frame_depth: int = 0
+    runtime_error_count: int = 0
+    wall_time_ns: int = 0
+    opcode_counts: dict[str, int] = field(default_factory=dict)
+
+
+ProfilingHook = Callable[[VMMetrics], None]
+
+
+__all__ = [
+    "ProfilingHook",
+    "VMMetrics",
+]

--- a/src/seme/vm_trace.py
+++ b/src/seme/vm_trace.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Callable
+
+from seme.bytecode import Instruction, OpCode, SourceSpan
+
+
+class TracePhase(StrEnum):
+    BEFORE = "before"
+    AFTER = "after"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    phase: TracePhase
+    offset: int
+    instruction: Instruction
+    span: SourceSpan
+    stack_depth: int
+    frame_depth: int
+
+
+TraceHook = Callable[[TraceEvent], None]
+
+
+__all__ = [
+    "TraceEvent",
+    "TraceHook",
+    "TracePhase",
+]

--- a/tests/cli/test_debug_cli.py
+++ b/tests/cli/test_debug_cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from seme.cli import main
+
+
+def test_debug_bytecode_prints_disassembly(tmp_path: Path, capsys) -> None:
+    source_file = tmp_path / "debug_bytecode.seme"
+    source_file.write_text("let x = 1; print(x);", encoding="utf-8")
+
+    code = main(["debug", "bytecode", str(source_file)])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert captured.err == ""
+    assert "0000 LOAD_CONST 0 (1) ; 1:9" in captured.out
+    assert "0001 DEFINE_GLOBAL 1 (x) ; 1:1" in captured.out
+    assert "0003 LOAD_GLOBAL 2 (x) ; 1:18" in captured.out
+    assert "0004 PRINT ; 1:17" in captured.out
+    assert captured.out.rstrip().endswith("RETURN ; 1:1")
+
+
+def test_debug_bytecode_returns_parse_error(tmp_path: Path, capsys) -> None:
+    source_file = tmp_path / "debug_bytecode_bad.seme"
+    source_file.write_text("let x = 1", encoding="utf-8")
+
+    code = main(["debug", "bytecode", str(source_file)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert captured.out == ""
+    assert "PARSE-001" in captured.err

--- a/tests/cli/test_repl_cli.py
+++ b/tests/cli/test_repl_cli.py
@@ -74,3 +74,18 @@ def test_repl_preserves_column_with_leading_spaces() -> None:
 
     assert code == 0
     assert "LEX-001 1:4" in err.getvalue()
+
+
+def test_repl_matches_run_backend_for_shadowing_and_builtin_output() -> None:
+    inp = StringIO(
+        "let x = 1;\n{ let x = 2; print(x); }\nprint(x);\n:quit\n"
+    )
+    out = StringIO()
+    err = StringIO()
+
+    code = repl_loop(inp, out, err)
+
+    assert code == 0
+    assert out.getvalue().count("2\n") == 1
+    assert out.getvalue().count("1\n") == 1
+    assert err.getvalue() == ""

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -77,3 +77,15 @@ def test_run_print_in_value_context_returns_type008(tmp_path: Path, capsys) -> N
     assert captured.out == ""
     assert "TYPE-008 1:6 print(expr) can only appear as a statement" in captured.err
     assert "TYPE-008 1:18 print(expr) can only appear as a statement" in captured.err
+
+
+def test_run_backend_interpreter_is_available_for_reference(tmp_path: Path, capsys) -> None:
+    source_file = tmp_path / "run_interpreter_backend.seme"
+    source_file.write_text("let x = 1; x = x + 2; print(x);", encoding="utf-8")
+
+    code = main(["run", "--backend", "interpreter", str(source_file)])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert captured.out == "3\n"
+    assert captured.err == ""

--- a/tests/fixtures/run_cases.json
+++ b/tests/fixtures/run_cases.json
@@ -81,5 +81,19 @@
         "column": 18
       }
     ]
+  },
+  {
+    "name": "run nested scope shadowing",
+    "source": "let x = 1; { let x = 2; print(x); } print(x);",
+    "expected_exit_code": 0,
+    "expected_stdout": "2\n1\n",
+    "expected_diagnostics": []
+  },
+  {
+    "name": "run string builtin parity",
+    "source": "let msg = \"hi\"; print(msg); print(msg == \"hi\");",
+    "expected_exit_code": 0,
+    "expected_stdout": "hi\ntrue\n",
+    "expected_diagnostics": []
   }
 ]

--- a/tests/unit/test_bytecode.py
+++ b/tests/unit/test_bytecode.py
@@ -31,6 +31,9 @@ def test_chunk_preserves_parallel_instruction_and_source_map_lengths() -> None:
 
 
 def test_documented_instruction_set_covers_control_flow_and_runtime_ops() -> None:
+    assert OpCode.LOAD_GLOBAL in BYTECODE_INSTRUCTION_SET
+    assert OpCode.DEFINE_GLOBAL in BYTECODE_INSTRUCTION_SET
+    assert OpCode.STORE_GLOBAL in BYTECODE_INSTRUCTION_SET
     assert OpCode.JUMP in BYTECODE_INSTRUCTION_SET
     assert OpCode.JUMP_IF_FALSE in BYTECODE_INSTRUCTION_SET
     assert OpCode.PRINT in BYTECODE_INSTRUCTION_SET

--- a/tests/unit/test_bytecode.py
+++ b/tests/unit/test_bytecode.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from seme.bytecode import BYTECODE_INSTRUCTION_SET, Chunk, OpCode, SourceSpan
+
+
+def test_chunk_emits_instruction_and_source_location() -> None:
+    chunk = Chunk()
+
+    const_index = chunk.add_constant(42)
+    offset = chunk.emit(OpCode.LOAD_CONST, const_index, span=SourceSpan(line=3, column=5))
+
+    assert const_index == 0
+    assert offset == 0
+    assert chunk.instructions[0].opcode is OpCode.LOAD_CONST
+    assert chunk.instructions[0].operands == (0,)
+    assert chunk.span_for_offset(0) == SourceSpan(line=3, column=5)
+
+
+def test_chunk_preserves_parallel_instruction_and_source_map_lengths() -> None:
+    chunk = Chunk()
+
+    chunk.emit(OpCode.LOAD_CONST, 0, span=SourceSpan(line=1, column=1))
+    chunk.emit(OpCode.PRINT, span=SourceSpan(line=1, column=10))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=17))
+
+    assert len(chunk.instructions) == 3
+    assert len(chunk.source_map) == 3
+
+
+def test_documented_instruction_set_covers_control_flow_and_runtime_ops() -> None:
+    assert OpCode.JUMP in BYTECODE_INSTRUCTION_SET
+    assert OpCode.JUMP_IF_FALSE in BYTECODE_INSTRUCTION_SET
+    assert OpCode.PRINT in BYTECODE_INSTRUCTION_SET
+    assert OpCode.RETURN in BYTECODE_INSTRUCTION_SET

--- a/tests/unit/test_bytecode.py
+++ b/tests/unit/test_bytecode.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 from seme.bytecode import BYTECODE_INSTRUCTION_SET, Chunk, OpCode, SourceSpan
+from seme.compiler import BytecodeBuilder
+from seme.runtime import SemeBool, SemeInt, SemeString
 
 
 def test_chunk_emits_instruction_and_source_location() -> None:
     chunk = Chunk()
 
-    const_index = chunk.add_constant(42)
+    const_index = chunk.add_constant(SemeInt(42))
     offset = chunk.emit(OpCode.LOAD_CONST, const_index, span=SourceSpan(line=3, column=5))
 
     assert const_index == 0
     assert offset == 0
     assert chunk.instructions[0].opcode is OpCode.LOAD_CONST
     assert chunk.instructions[0].operands == (0,)
+    assert chunk.constants == [SemeInt(42)]
     assert chunk.span_for_offset(0) == SourceSpan(line=3, column=5)
 
 
@@ -32,3 +35,18 @@ def test_documented_instruction_set_covers_control_flow_and_runtime_ops() -> Non
     assert OpCode.JUMP_IF_FALSE in BYTECODE_INSTRUCTION_SET
     assert OpCode.PRINT in BYTECODE_INSTRUCTION_SET
     assert OpCode.RETURN in BYTECODE_INSTRUCTION_SET
+
+
+def test_builder_wraps_literal_constants_as_runtime_values() -> None:
+    builder = BytecodeBuilder()
+
+    int_index = builder.add_literal_constant(7)
+    bool_index = builder.add_literal_constant(True)
+    string_index = builder.add_literal_constant("hello")
+
+    assert (int_index, bool_index, string_index) == (0, 1, 2)
+    assert builder.chunk.constants == [
+        SemeInt(7),
+        SemeBool(True),
+        SemeString("hello"),
+    ]

--- a/tests/unit/test_bytecode_cache.py
+++ b/tests/unit/test_bytecode_cache.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, OpCode, SourceSpan
+from seme.bytecode_cache import BytecodeCache
+from seme.runtime import SemeInt
+
+
+def test_bytecode_cache_reuses_serialized_chunk_for_same_source_and_version() -> None:
+    cache = BytecodeCache()
+    build_calls = {"count": 0}
+
+    def build() -> Chunk:
+        build_calls["count"] += 1
+        chunk = Chunk()
+        chunk.add_constant(SemeInt(1))
+        chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=1))
+        return chunk
+
+    first = cache.get_or_build(source_hash="abc", compiler_version="v1", build=build)
+    second = cache.get_or_build(source_hash="abc", compiler_version="v1", build=build)
+
+    assert build_calls["count"] == 1
+    assert first == second
+    assert first is not second
+
+
+def test_bytecode_cache_invalidates_on_version_change() -> None:
+    cache = BytecodeCache()
+    build_calls = {"count": 0}
+
+    def build() -> Chunk:
+        build_calls["count"] += 1
+        chunk = Chunk()
+        chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=1))
+        return chunk
+
+    cache.get_or_build(source_hash="abc", compiler_version="v1", build=build)
+    cache.get_or_build(source_hash="abc", compiler_version="v2", build=build)
+
+    assert build_calls["count"] == 2

--- a/tests/unit/test_bytecode_disassembler.py
+++ b/tests/unit/test_bytecode_disassembler.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, OpCode, SourceSpan
+from seme.bytecode_disassembler import disassemble_chunk
+from seme.runtime import SemeBool, SemeInt, SemeString
+
+
+def test_disassemble_chunk_renders_constants_and_source_locations() -> None:
+    chunk = Chunk()
+    int_index = chunk.add_constant(SemeInt(7))
+    bool_index = chunk.add_constant(SemeBool(True))
+    string_index = chunk.add_constant(SemeString("hi"))
+
+    chunk.emit(OpCode.LOAD_CONST, int_index, span=SourceSpan(line=2, column=3))
+    chunk.emit(OpCode.LOAD_CONST, bool_index, span=SourceSpan(line=2, column=10))
+    chunk.emit(OpCode.LOAD_GLOBAL, string_index, span=SourceSpan(line=2, column=20))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=2, column=30))
+
+    assert disassemble_chunk(chunk) == [
+        "0000 LOAD_CONST 0 (7) ; 2:3",
+        "0001 LOAD_CONST 1 (true) ; 2:10",
+        "0002 LOAD_GLOBAL 2 (hi) ; 2:20",
+        "0003 RETURN ; 2:30",
+    ]
+
+
+def test_disassemble_chunk_falls_back_to_raw_operand_for_incomplete_chunks() -> None:
+    chunk = Chunk()
+    chunk.emit(OpCode.LOAD_CONST, 99, span=SourceSpan(line=1, column=1))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=2))
+
+    assert disassemble_chunk(chunk) == [
+        "0000 LOAD_CONST 99 ; 1:1",
+        "0001 RETURN ; 1:2",
+    ]

--- a/tests/unit/test_bytecode_peephole.py
+++ b/tests/unit/test_bytecode_peephole.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, OpCode, SourceSpan
+from seme.bytecode_peephole import optimize_chunk
+from seme.compiler import compile_program
+from seme.lexer import lex
+from seme.parser import parse
+from seme.runtime import SemeInt
+from seme.typechecker import check_types
+
+
+def compile_source(source: str, *, optimize: bool = True) -> Chunk:
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return compile_program(program, optimize=optimize)
+
+
+def test_optimize_chunk_folds_literals_and_removes_dead_stack_churn() -> None:
+    chunk = Chunk()
+    left = chunk.add_constant(SemeInt(1))
+    right = chunk.add_constant(SemeInt(2))
+
+    chunk.emit(OpCode.LOAD_CONST, left, span=SourceSpan(1, 1))
+    chunk.emit(OpCode.LOAD_CONST, right, span=SourceSpan(1, 5))
+    chunk.emit(OpCode.ADD, span=SourceSpan(1, 7))
+    chunk.emit(OpCode.POP, span=SourceSpan(1, 8))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(1, 9))
+
+    optimized = optimize_chunk(chunk)
+
+    assert [instruction.opcode.value for instruction in optimized.instructions] == ["RETURN"]
+    assert optimized.constants == [SemeInt(1), SemeInt(2), SemeInt(3)]
+    assert optimized.span_for_offset(0) == SourceSpan(1, 9)
+
+
+def test_compile_program_can_disable_peephole_optimization() -> None:
+    raw_chunk = compile_source("1 + 2;", optimize=False)
+
+    assert [instruction.opcode.value for instruction in raw_chunk.instructions] == [
+        "LOAD_CONST",
+        "LOAD_CONST",
+        "ADD",
+        "POP",
+        "RETURN",
+    ]
+
+
+def test_compile_program_peephole_folds_nested_constant_expressions() -> None:
+    chunk = compile_source("print(1 + 2 * 3);")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "PRINT",
+        "RETURN",
+    ]
+    assert chunk.constants[-1] == SemeInt(7)

--- a/tests/unit/test_bytecode_serialization.py
+++ b/tests/unit/test_bytecode_serialization.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, OpCode, SourceSpan
+from seme.bytecode_serialization import deserialize_chunk, serialize_chunk
+from seme.runtime import HeapRef, SemeBool, SemeInt, SemeString
+
+
+def test_chunk_serialization_round_trips_instructions_constants_and_source_map() -> None:
+    chunk = Chunk()
+    chunk.add_constant(SemeInt(7))
+    chunk.add_constant(SemeBool(True))
+    chunk.add_constant(SemeString("hi"))
+    chunk.add_constant(HeapRef(object_id=5, kind="string"))
+    chunk.emit(OpCode.LOAD_CONST, 0, span=SourceSpan(line=2, column=3))
+    chunk.emit(OpCode.PRINT, span=SourceSpan(line=2, column=9))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=2, column=17))
+
+    restored = deserialize_chunk(serialize_chunk(chunk))
+
+    assert restored == chunk
+
+
+def test_serialized_chunk_is_json_stable_enough_for_cache_use() -> None:
+    chunk = Chunk()
+    chunk.add_constant(SemeString("hello"))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=1))
+
+    serialized = serialize_chunk(chunk)
+
+    assert '"instructions":[{"opcode":"RETURN","operands":[]}]' in serialized
+    assert '"kind":"string"' in serialized

--- a/tests/unit/test_bytecode_validator.py
+++ b/tests/unit/test_bytecode_validator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
+from seme.bytecode_validator import validate_chunk
+from seme.runtime import SemeInt, SemeString
+
+
+def test_validate_chunk_accepts_well_formed_chunk() -> None:
+    chunk = Chunk()
+    const_index = chunk.add_constant(SemeInt(1))
+    chunk.emit(OpCode.LOAD_CONST, const_index, span=SourceSpan(line=1, column=1))
+    chunk.emit(OpCode.RETURN, span=SourceSpan(line=1, column=10))
+
+    assert validate_chunk(chunk) == []
+
+
+def test_validate_chunk_rejects_source_map_length_mismatch() -> None:
+    chunk = Chunk()
+    chunk.instructions.append(Instruction(opcode=OpCode.RETURN))
+
+    diagnostics = validate_chunk(chunk)
+
+    assert [(d.code, d.message, d.line, d.column) for d in diagnostics] == [
+        (
+            "BYTECODE-001",
+            "bytecode chunk instructions and source map lengths must match",
+            1,
+            1,
+        )
+    ]
+
+
+def test_validate_chunk_rejects_invalid_jump_target_and_name_constant() -> None:
+    chunk = Chunk()
+    chunk.constants.append(SemeInt(1))
+    chunk.instructions.extend(
+        [
+            Instruction(opcode=OpCode.JUMP, operands=(5,)),
+            Instruction(opcode=OpCode.LOAD_GLOBAL, operands=(0,)),
+            Instruction(opcode=OpCode.RETURN),
+        ]
+    )
+    chunk.source_map.extend(
+        [
+            SourceSpan(line=1, column=1),
+            SourceSpan(line=1, column=2),
+            SourceSpan(line=1, column=3),
+        ]
+    )
+
+    diagnostics = validate_chunk(chunk)
+
+    assert [(d.code, d.message, d.line, d.column) for d in diagnostics] == [
+        ("BYTECODE-002", "JUMP target 5 is out of range", 1, 1),
+        ("BYTECODE-002", "LOAD_GLOBAL requires a string constant operand", 1, 2),
+    ]

--- a/tests/unit/test_compiler_basic.py
+++ b/tests/unit/test_compiler_basic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from seme.compiler import compile_program
 from seme.lexer import lex
 from seme.parser import parse
+from seme.runtime import SemeBool, SemeInt, SemeString
 from seme.typechecker import check_types
 
 
@@ -34,7 +35,7 @@ def test_compile_linear_program_with_decls_assign_and_print() -> None:
     ]
     assert chunk.instructions[1].operands == (0,)
     assert chunk.instructions[6].operands == (0,)
-    assert chunk.constants == [1, 2]
+    assert chunk.constants == [SemeInt(1), SemeInt(2)]
 
 
 def test_compile_uninitialized_let_uses_sentinel_opcode() -> None:
@@ -62,4 +63,14 @@ def test_compile_logical_and_uses_short_circuit_jumps() -> None:
     ]
     assert chunk.instructions[1].operands == (5,)
     assert chunk.instructions[4].operands == (7,)
-    assert chunk.constants == [True, False, False]
+    assert chunk.constants == [SemeBool(True), SemeBool(False), SemeBool(False)]
+
+
+def test_compile_mixed_literal_kinds_to_runtime_value_constants() -> None:
+    chunk = compile_source('let n = 1; let ok = false; let msg = "hi";')
+
+    assert chunk.constants == [
+        SemeInt(1),
+        SemeBool(False),
+        SemeString("hi"),
+    ]

--- a/tests/unit/test_compiler_basic.py
+++ b/tests/unit/test_compiler_basic.py
@@ -22,27 +22,32 @@ def test_compile_linear_program_with_decls_assign_and_print() -> None:
 
     assert [instruction.opcode.value for instruction in chunk.instructions] == [
         "LOAD_CONST",
-        "STORE_LOCAL",
+        "DEFINE_GLOBAL",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "LOAD_CONST",
         "ADD",
-        "STORE_LOCAL",
+        "STORE_GLOBAL",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "PRINT",
         "RETURN",
     ]
-    assert chunk.instructions[1].operands == (0,)
-    assert chunk.instructions[6].operands == (0,)
-    assert chunk.constants == [SemeInt(1), SemeInt(2)]
+    assert chunk.constants[0] == SemeInt(1)
+    assert chunk.constants[3] == SemeInt(2)
+    assert [const for const in chunk.constants if const == SemeString("x")] == [
+        SemeString("x"),
+        SemeString("x"),
+        SemeString("x"),
+        SemeString("x"),
+    ]
 
 
 def test_compile_uninitialized_let_uses_sentinel_opcode() -> None:
     chunk = compile_source("let x: int; print(1);")
 
     assert chunk.instructions[0].opcode.value == "LOAD_UNINITIALIZED"
-    assert chunk.instructions[1].opcode.value == "STORE_LOCAL"
+    assert chunk.instructions[1].opcode.value == "DEFINE_GLOBAL"
     assert chunk.instructions[-1].opcode.value == "RETURN"
 
 
@@ -57,13 +62,14 @@ def test_compile_logical_and_uses_short_circuit_jumps() -> None:
         "JUMP",
         "POP",
         "LOAD_CONST",
-        "STORE_LOCAL",
+        "DEFINE_GLOBAL",
         "POP",
         "RETURN",
     ]
     assert chunk.instructions[1].operands == (5,)
     assert chunk.instructions[4].operands == (7,)
-    assert chunk.constants == [SemeBool(True), SemeBool(False), SemeBool(False)]
+    assert chunk.constants[:3] == [SemeBool(True), SemeBool(False), SemeBool(False)]
+    assert chunk.constants[-1] == SemeString("x")
 
 
 def test_compile_mixed_literal_kinds_to_runtime_value_constants() -> None:
@@ -71,6 +77,28 @@ def test_compile_mixed_literal_kinds_to_runtime_value_constants() -> None:
 
     assert chunk.constants == [
         SemeInt(1),
+        SemeString("n"),
         SemeBool(False),
+        SemeString("ok"),
         SemeString("hi"),
+        SemeString("msg"),
+    ]
+
+
+def test_compile_nested_scope_reads_global_but_stores_local_shadow() -> None:
+    chunk = compile_source("let x = 1; { let x = 2; print(x); } print(x);")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "DEFINE_GLOBAL",
+        "POP",
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "PRINT",
+        "POP_N",
+        "LOAD_GLOBAL",
+        "PRINT",
+        "RETURN",
     ]

--- a/tests/unit/test_compiler_basic.py
+++ b/tests/unit/test_compiler_basic.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from seme.compiler import compile_program
+from seme.lexer import lex
+from seme.parser import parse
+from seme.typechecker import check_types
+
+
+def compile_source(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return compile_program(program)
+
+
+def test_compile_linear_program_with_decls_assign_and_print() -> None:
+    chunk = compile_source("let x = 1; x = x + 2; print(x);")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "ADD",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "PRINT",
+        "RETURN",
+    ]
+    assert chunk.instructions[1].operands == (0,)
+    assert chunk.instructions[6].operands == (0,)
+    assert chunk.constants == [1, 2]
+
+
+def test_compile_uninitialized_let_uses_sentinel_opcode() -> None:
+    chunk = compile_source("let x: int; print(1);")
+
+    assert chunk.instructions[0].opcode.value == "LOAD_UNINITIALIZED"
+    assert chunk.instructions[1].opcode.value == "STORE_LOCAL"
+    assert chunk.instructions[-1].opcode.value == "RETURN"
+
+
+def test_compile_logical_and_uses_short_circuit_jumps() -> None:
+    chunk = compile_source("let x = true && false;")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "JUMP_IF_FALSE",
+        "POP",
+        "LOAD_CONST",
+        "JUMP",
+        "POP",
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "RETURN",
+    ]
+    assert chunk.instructions[1].operands == (5,)
+    assert chunk.instructions[4].operands == (7,)
+    assert chunk.constants == [True, False, False]

--- a/tests/unit/test_compiler_control_flow.py
+++ b/tests/unit/test_compiler_control_flow.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from seme.compiler import compile_program
+from seme.lexer import lex
+from seme.parser import parse
+from seme.typechecker import check_types
+
+
+def compile_source(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return compile_program(program)
+
+
+def test_compile_if_else_uses_branch_and_join_jumps() -> None:
+    chunk = compile_source("let x = 1; if (x < 2) { print(x); } else { print(2); }")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "LESS",
+        "JUMP_IF_FALSE",
+        "POP",
+        "LOAD_LOCAL",
+        "PRINT",
+        "JUMP",
+        "POP",
+        "LOAD_CONST",
+        "PRINT",
+        "RETURN",
+    ]
+    assert chunk.instructions[6].operands == (11,)
+    assert chunk.instructions[10].operands == (14,)
+
+
+def test_compile_while_loop_back_edges_to_condition() -> None:
+    chunk = compile_source("let x = 0; while (x < 2) { x = x + 1; }")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "LESS",
+        "JUMP_IF_FALSE",
+        "POP",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "ADD",
+        "STORE_LOCAL",
+        "POP",
+        "JUMP",
+        "POP",
+        "RETURN",
+    ]
+    assert chunk.instructions[6].operands == (14,)
+    assert chunk.instructions[13].operands == (3,)
+
+
+def test_compile_for_preserves_init_condition_body_update_order() -> None:
+    chunk = compile_source("for (let i = 0; i < 2; i = i + 1) { print(i); }")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "LESS",
+        "JUMP_IF_FALSE",
+        "POP",
+        "LOAD_LOCAL",
+        "PRINT",
+        "LOAD_LOCAL",
+        "LOAD_CONST",
+        "ADD",
+        "STORE_LOCAL",
+        "POP",
+        "JUMP",
+        "POP",
+        "POP_N",
+        "RETURN",
+    ]
+    assert chunk.instructions[6].operands == (16,)
+    assert chunk.instructions[15].operands == (3,)
+
+
+def test_compile_nested_blocks_cleanup_only_inner_slots() -> None:
+    chunk = compile_source("let x = 1; { let y = 2; print(y); } print(x);")
+
+    assert [instruction.opcode.value for instruction in chunk.instructions] == [
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_CONST",
+        "STORE_LOCAL",
+        "POP",
+        "LOAD_LOCAL",
+        "PRINT",
+        "POP_N",
+        "LOAD_LOCAL",
+        "PRINT",
+        "RETURN",
+    ]
+    assert chunk.instructions[1].operands == (0,)
+    assert chunk.instructions[4].operands == (1,)

--- a/tests/unit/test_compiler_control_flow.py
+++ b/tests/unit/test_compiler_control_flow.py
@@ -21,14 +21,14 @@ def test_compile_if_else_uses_branch_and_join_jumps() -> None:
 
     assert [instruction.opcode.value for instruction in chunk.instructions] == [
         "LOAD_CONST",
-        "STORE_LOCAL",
+        "DEFINE_GLOBAL",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "LOAD_CONST",
         "LESS",
         "JUMP_IF_FALSE",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "PRINT",
         "JUMP",
         "POP",
@@ -45,17 +45,17 @@ def test_compile_while_loop_back_edges_to_condition() -> None:
 
     assert [instruction.opcode.value for instruction in chunk.instructions] == [
         "LOAD_CONST",
-        "STORE_LOCAL",
+        "DEFINE_GLOBAL",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "LOAD_CONST",
         "LESS",
         "JUMP_IF_FALSE",
         "POP",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "LOAD_CONST",
         "ADD",
-        "STORE_LOCAL",
+        "STORE_GLOBAL",
         "POP",
         "JUMP",
         "POP",
@@ -98,7 +98,7 @@ def test_compile_nested_blocks_cleanup_only_inner_slots() -> None:
 
     assert [instruction.opcode.value for instruction in chunk.instructions] == [
         "LOAD_CONST",
-        "STORE_LOCAL",
+        "DEFINE_GLOBAL",
         "POP",
         "LOAD_CONST",
         "STORE_LOCAL",
@@ -106,9 +106,8 @@ def test_compile_nested_blocks_cleanup_only_inner_slots() -> None:
         "LOAD_LOCAL",
         "PRINT",
         "POP_N",
-        "LOAD_LOCAL",
+        "LOAD_GLOBAL",
         "PRINT",
         "RETURN",
     ]
-    assert chunk.instructions[1].operands == (0,)
-    assert chunk.instructions[4].operands == (1,)
+    assert chunk.instructions[4].operands == (0,)

--- a/tests/unit/test_compiler_scaffolding.py
+++ b/tests/unit/test_compiler_scaffolding.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from seme.bytecode import OpCode, SourceSpan
+from seme.compiler import BytecodeBuilder, CompilerState
+
+
+def test_emit_jump_then_bind_label_patches_forward_target() -> None:
+    builder = BytecodeBuilder()
+    exit_label = builder.new_label("exit")
+
+    jump_offset = builder.emit_jump(OpCode.JUMP_IF_FALSE, exit_label, span=SourceSpan(line=1, column=4))
+    builder.emit(OpCode.LOAD_CONST, 0, span=SourceSpan(line=1, column=10))
+    bound_offset = builder.bind_label(exit_label)
+
+    assert jump_offset == 0
+    assert bound_offset == 2
+    assert builder.chunk.instructions[0].operands == (2,)
+    assert exit_label.patch_sites == []
+
+
+def test_compiler_state_tracks_scope_depth_and_locals() -> None:
+    state = CompilerState()
+
+    outer = state.declare_local("x", is_const=False)
+    state.begin_scope()
+    inner = state.declare_local("x", is_const=True)
+
+    assert outer.slot == 0
+    assert outer.depth == 0
+    assert inner.slot == 1
+    assert inner.depth == 1
+    assert state.resolve_local("x") == inner
+
+    dropped = state.end_scope()
+
+    assert dropped == [inner]
+    assert state.resolve_local("x") == outer
+
+
+def test_render_produces_human_readable_bytecode_listing() -> None:
+    builder = BytecodeBuilder()
+
+    builder.emit(OpCode.LOAD_CONST, 0, span=SourceSpan(line=2, column=3))
+    builder.emit(OpCode.PRINT, span=SourceSpan(line=2, column=9))
+
+    assert builder.render() == [
+        "0000 LOAD_CONST 0 ; 2:3",
+        "0001 PRINT ; 2:9",
+    ]

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from seme.interpreter import Interpreter, eval_program
 from seme.lexer import lex
 from seme.parser import parse
-from seme.runtime import SemeBool, SemeInt
+from seme.runtime import HeapRef, SemeBool, SemeInt
 from seme.typechecker import check_types
 
 
@@ -101,3 +101,15 @@ def test_interpreter_stores_runtime_value_objects_in_bindings() -> None:
     assert diags == []
     assert interpreter._resolve("x").value == SemeInt(3)
     assert interpreter._resolve("ok").value == SemeBool(True)
+
+
+def test_interpreter_exposes_gc_root_values_for_live_bindings() -> None:
+    program = parse_checked_program('let msg = "hi"; let count = 1;')
+    interpreter = Interpreter()
+
+    lines, diags = interpreter.execute(program)
+
+    assert lines == []
+    assert diags == []
+    assert any(isinstance(value, HeapRef) for value in interpreter.gc_root_values())
+    assert interpreter.heap.live_object_ids(interpreter.gc_root_values()) == {1}

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from seme.interpreter import eval_program
+from seme.interpreter import Interpreter, eval_program
 from seme.lexer import lex
 from seme.parser import parse
+from seme.runtime import SemeBool, SemeInt
 from seme.typechecker import check_types
 
 
@@ -14,6 +15,16 @@ def eval_source(source: str):
     type_diags = check_types(program)
     assert type_diags == []
     return eval_program(program)
+
+
+def parse_checked_program(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return program
 
 
 def test_arithmetic_and_print_output() -> None:
@@ -78,3 +89,15 @@ def test_runtime_error_uninitialized_variable() -> None:
     assert len(diags) == 1
     assert diags[0].code == "RUNTIME-001"
     assert "uninitialized" in diags[0].message
+
+
+def test_interpreter_stores_runtime_value_objects_in_bindings() -> None:
+    program = parse_checked_program("let x = 1 + 2; let ok = x == 3;")
+    interpreter = Interpreter()
+
+    lines, diags = interpreter.execute(program)
+
+    assert lines == []
+    assert diags == []
+    assert interpreter._resolve("x").value == SemeInt(3)
+    assert interpreter._resolve("ok").value == SemeBool(True)

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from seme.bytecode_cache import BytecodeCache
 from seme.pipeline import run_execute
 
 
@@ -86,4 +87,30 @@ print(sum);
     assert vm_stdout == interp_stdout
     assert [(d.code, d.message, d.line, d.column) for d in vm_diags] == [
         (d.code, d.message, d.line, d.column) for d in interp_diags
+    ]
+
+
+def test_run_execute_vm_and_interpreter_match_on_string_literals() -> None:
+    source = 'let msg = "hi"; print(msg); print(msg == "hi");'
+
+    vm_stdout, vm_diags = run_execute(source, backend="vm")
+    interp_stdout, interp_diags = run_execute(source, backend="interpreter")
+
+    assert vm_stdout == "hi\ntrue\n"
+    assert vm_stdout == interp_stdout
+    assert [(d.code, d.message, d.line, d.column) for d in vm_diags] == [
+        (d.code, d.message, d.line, d.column) for d in interp_diags
+    ]
+
+
+def test_run_execute_vm_cache_matches_uncached_execution() -> None:
+    source = 'let msg = "hi"; print(msg);'
+    cache = BytecodeCache()
+
+    cached_stdout, cached_diags = run_execute(source, backend="vm", cache=cache)
+    uncached_stdout, uncached_diags = run_execute(source, backend="vm")
+
+    assert cached_stdout == uncached_stdout == "hi\n"
+    assert [(d.code, d.message, d.line, d.column) for d in cached_diags] == [
+        (d.code, d.message, d.line, d.column) for d in uncached_diags
     ]

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -68,3 +68,22 @@ def test_run_execute_print_bad_arity_in_value_context_is_single_type_error() -> 
     ] == [
         ("TYPE-008", "print requires exactly one argument", 1, 14),
     ]
+
+
+def test_run_execute_vm_and_interpreter_backends_match() -> None:
+    source = """
+let sum = 0;
+for (let i = 0; i < 4; i = i + 1) {
+  if (i < 3) {
+    sum = sum + i;
+  }
+}
+print(sum);
+""".strip()
+    vm_stdout, vm_diags = run_execute(source, backend="vm")
+    interp_stdout, interp_diags = run_execute(source, backend="interpreter")
+
+    assert vm_stdout == interp_stdout
+    assert [(d.code, d.message, d.line, d.column) for d in vm_diags] == [
+        (d.code, d.message, d.line, d.column) for d in interp_diags
+    ]

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from seme.runtime import (
+    RuntimeValueError,
+    SemeBool,
+    SemeInt,
+    SemeString,
+    UNINITIALIZED,
+    VOID,
+    expect_bool,
+    expect_int,
+    expect_string,
+    format_runtime_value,
+    is_bool_value,
+    is_int_value,
+    is_runtime_value,
+    is_string_value,
+    is_uninitialized,
+    is_void,
+    make_runtime_value,
+    require_runtime_value,
+    runtime_arithmetic,
+    runtime_compare,
+    runtime_equal,
+    runtime_negate,
+    runtime_not,
+    runtime_raw_value,
+    same_runtime_type,
+)
+
+
+def test_make_runtime_value_wraps_language_literals() -> None:
+    assert make_runtime_value(7) == SemeInt(7)
+    assert make_runtime_value(True) == SemeBool(True)
+    assert make_runtime_value("hi") == SemeString("hi")
+
+
+def test_runtime_formatting_matches_cli_output_conventions() -> None:
+    assert format_runtime_value(SemeBool(True)) == "true"
+    assert format_runtime_value(SemeBool(False)) == "false"
+    assert format_runtime_value(SemeInt(12)) == "12"
+    assert format_runtime_value(SemeString("hello")) == "hello"
+
+
+def test_runtime_type_helpers_distinguish_supported_values() -> None:
+    int_value = SemeInt(1)
+    bool_value = SemeBool(False)
+    string_value = SemeString("x")
+
+    assert is_runtime_value(int_value)
+    assert is_runtime_value(bool_value)
+    assert is_runtime_value(string_value)
+    assert not is_runtime_value(UNINITIALIZED)
+    assert not is_runtime_value(VOID)
+    assert is_uninitialized(UNINITIALIZED)
+    assert not is_uninitialized(int_value)
+    assert is_void(VOID)
+    assert not is_void(string_value)
+    assert is_int_value(int_value)
+    assert not is_int_value(bool_value)
+    assert is_bool_value(bool_value)
+    assert is_string_value(string_value)
+
+
+def test_runtime_equality_helpers_compare_by_runtime_type() -> None:
+    assert same_runtime_type(SemeInt(1), SemeInt(2))
+    assert not same_runtime_type(SemeInt(1), SemeBool(True))
+    assert runtime_raw_value(SemeString("abc")) == "abc"
+
+
+def test_runtime_operation_helpers_cover_success_paths() -> None:
+    assert expect_bool(SemeBool(True), "bad") is True
+    assert expect_int(SemeInt(3), "bad") == 3
+    assert expect_string(SemeString("ok"), "bad") == "ok"
+    assert runtime_not(SemeBool(False)) == SemeBool(True)
+    assert runtime_negate(SemeInt(4)) == SemeInt(-4)
+    assert runtime_arithmetic("add", SemeInt(2), SemeInt(5)) == SemeInt(7)
+    assert runtime_compare("gte", SemeInt(5), SemeInt(5)) == SemeBool(True)
+    assert runtime_equal("eq", SemeString("x"), SemeString("x")) == SemeBool(True)
+
+
+def test_runtime_operation_helpers_cover_failure_paths() -> None:
+    try:
+        require_runtime_value(VOID)
+    except RuntimeValueError as err:
+        assert err.message == "expression does not produce a value"
+    else:
+        raise AssertionError("expected VOID to be rejected")
+
+    try:
+        runtime_arithmetic("div", SemeInt(1), SemeInt(0))
+    except RuntimeValueError as err:
+        assert err.message == "division or modulo by zero"
+    else:
+        raise AssertionError("expected zero division to be rejected")
+
+    try:
+        runtime_equal("eq", SemeInt(1), SemeBool(True))
+    except RuntimeValueError as err:
+        assert err.message == "equality operators require matching types"
+    else:
+        raise AssertionError("expected mixed equality to be rejected")
+
+    try:
+        expect_string(SemeInt(1), "string required")
+    except RuntimeValueError as err:
+        assert err.message == "string required"
+    else:
+        raise AssertionError("expected bad string conversion to be rejected")

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
+from seme.builtins import DEFAULT_BUILTINS
 from seme.runtime import (
+    HeapRef,
+    RuntimeHeap,
     RuntimeValueError,
     SemeBool,
     SemeInt,
     SemeString,
     UNINITIALIZED,
     VOID,
+    allocate_string,
     expect_bool,
     expect_int,
     expect_string,
@@ -29,27 +35,50 @@ from seme.runtime import (
 )
 
 
+@dataclass
+class RecordingHost:
+    lines: list[str] = field(default_factory=list)
+    heap: RuntimeHeap = field(default_factory=RuntimeHeap)
+
+    @property
+    def runtime_heap(self) -> RuntimeHeap:
+        return self.heap
+
+    def write_stdout_line(self, line: str) -> None:
+        self.lines.append(line)
+
+
 def test_make_runtime_value_wraps_language_literals() -> None:
+    heap = RuntimeHeap()
+
     assert make_runtime_value(7) == SemeInt(7)
     assert make_runtime_value(True) == SemeBool(True)
     assert make_runtime_value("hi") == SemeString("hi")
+    assert make_runtime_value("hi", heap=heap) == HeapRef(object_id=1, kind="string")
 
 
 def test_runtime_formatting_matches_cli_output_conventions() -> None:
+    heap = RuntimeHeap()
+    string_ref = allocate_string("hello", heap)
+
     assert format_runtime_value(SemeBool(True)) == "true"
     assert format_runtime_value(SemeBool(False)) == "false"
     assert format_runtime_value(SemeInt(12)) == "12"
     assert format_runtime_value(SemeString("hello")) == "hello"
+    assert format_runtime_value(string_ref, heap=heap) == "hello"
 
 
 def test_runtime_type_helpers_distinguish_supported_values() -> None:
+    heap = RuntimeHeap()
     int_value = SemeInt(1)
     bool_value = SemeBool(False)
     string_value = SemeString("x")
+    heap_string = allocate_string("y", heap)
 
     assert is_runtime_value(int_value)
     assert is_runtime_value(bool_value)
     assert is_runtime_value(string_value)
+    assert is_runtime_value(heap_string)
     assert not is_runtime_value(UNINITIALIZED)
     assert not is_runtime_value(VOID)
     assert is_uninitialized(UNINITIALIZED)
@@ -60,26 +89,37 @@ def test_runtime_type_helpers_distinguish_supported_values() -> None:
     assert not is_int_value(bool_value)
     assert is_bool_value(bool_value)
     assert is_string_value(string_value)
+    assert is_string_value(heap_string)
 
 
 def test_runtime_equality_helpers_compare_by_runtime_type() -> None:
+    heap = RuntimeHeap()
+
     assert same_runtime_type(SemeInt(1), SemeInt(2))
     assert not same_runtime_type(SemeInt(1), SemeBool(True))
     assert runtime_raw_value(SemeString("abc")) == "abc"
+    assert same_runtime_type(allocate_string("a", heap), allocate_string("b", heap))
+    assert runtime_raw_value(allocate_string("abc", heap), heap=heap) == "abc"
 
 
 def test_runtime_operation_helpers_cover_success_paths() -> None:
+    heap = RuntimeHeap()
+
     assert expect_bool(SemeBool(True), "bad") is True
     assert expect_int(SemeInt(3), "bad") == 3
     assert expect_string(SemeString("ok"), "bad") == "ok"
+    assert expect_string(allocate_string("ok", heap), "bad", heap=heap) == "ok"
     assert runtime_not(SemeBool(False)) == SemeBool(True)
     assert runtime_negate(SemeInt(4)) == SemeInt(-4)
     assert runtime_arithmetic("add", SemeInt(2), SemeInt(5)) == SemeInt(7)
     assert runtime_compare("gte", SemeInt(5), SemeInt(5)) == SemeBool(True)
     assert runtime_equal("eq", SemeString("x"), SemeString("x")) == SemeBool(True)
+    assert runtime_equal("eq", allocate_string("x", heap), allocate_string("x", heap), heap=heap) == SemeBool(True)
 
 
 def test_runtime_operation_helpers_cover_failure_paths() -> None:
+    heap = RuntimeHeap()
+
     try:
         require_runtime_value(VOID)
     except RuntimeValueError as err:
@@ -107,3 +147,29 @@ def test_runtime_operation_helpers_cover_failure_paths() -> None:
         assert err.message == "string required"
     else:
         raise AssertionError("expected bad string conversion to be rejected")
+
+    try:
+        expect_string(allocate_string("x", heap), "string required")
+    except RuntimeValueError as err:
+        assert err.message == "string heap is required"
+    else:
+        raise AssertionError("expected heap-backed string without heap to be rejected")
+
+
+def test_builtin_registry_dispatches_print_through_host_interface() -> None:
+    host = RecordingHost()
+
+    result = DEFAULT_BUILTINS.invoke("print", [SemeBool(True)], host)
+
+    assert result is VOID
+    assert host.lines == ["true"]
+
+
+def test_runtime_heap_collects_root_object_ids_from_value_groups() -> None:
+    heap = RuntimeHeap()
+    first = allocate_string("a", heap)
+    second = allocate_string("b", heap)
+
+    assert heap.tracked_object_ids() == {1, 2}
+    assert heap.root_object_ids([first, SemeInt(1)], [second, VOID]) == {1, 2}
+    assert heap.live_object_ids([first], [SemeInt(1)]) == {1}

--- a/tests/unit/test_runtime_faults.py
+++ b/tests/unit/test_runtime_faults.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from seme.runtime_faults import (
+    RuntimeFault,
+    diagnostic_from_runtime_fault,
+    diagnostic_from_unexpected_runtime_error,
+)
+
+
+def test_runtime_fault_maps_to_runtime_001_diagnostic() -> None:
+    diagnostic = diagnostic_from_runtime_fault(
+        RuntimeFault(message="division or modulo by zero", line=2, column=12)
+    )
+
+    assert (diagnostic.code, diagnostic.message, diagnostic.line, diagnostic.column) == (
+        "RUNTIME-001",
+        "Runtime error: division or modulo by zero",
+        2,
+        12,
+    )
+
+
+def test_unexpected_runtime_error_maps_through_shared_helper() -> None:
+    diagnostic = diagnostic_from_unexpected_runtime_error(
+        ValueError("boom"),
+        line=4,
+        column=7,
+    )
+
+    assert (diagnostic.code, diagnostic.message, diagnostic.line, diagnostic.column) == (
+        "RUNTIME-001",
+        "Runtime error: boom",
+        4,
+        7,
+    )

--- a/tests/unit/test_runtime_tooling.py
+++ b/tests/unit/test_runtime_tooling.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from hashlib import sha256
+
+from seme.bytecode_cache import BytecodeCache
+from seme.bytecode_serialization import deserialize_chunk, serialize_chunk
+from seme.bytecode_validator import validate_chunk
+from seme.compiler import compile_program
+from seme.lexer import lex
+from seme.parser import parse
+from seme.runtime import SemeString
+from seme.typechecker import check_types
+from seme.vm import VirtualMachine
+from seme.vm_metrics import VMMetrics
+from seme.vm_trace import TracePhase
+
+
+def compile_checked_chunk(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return compile_program(program)
+
+
+def test_runtime_tooling_round_trip_validation_trace_and_metrics() -> None:
+    chunk = compile_checked_chunk('let msg = "hi"; print(msg);')
+    restored = deserialize_chunk(serialize_chunk(chunk))
+    trace_events = []
+    metrics: list[VMMetrics] = []
+    vm = VirtualMachine(restored, trace_hook=trace_events.append, profiling_hook=metrics.append)
+
+    validation_diags = validate_chunk(restored)
+    stdout_lines, runtime_diags = vm.execute()
+
+    assert validation_diags == []
+    assert stdout_lines == ["hi"]
+    assert runtime_diags == []
+    assert [event.phase for event in trace_events[:2]] == [TracePhase.BEFORE, TracePhase.AFTER]
+    assert any(event.instruction.opcode.value == "PRINT" for event in trace_events)
+    assert len(metrics) == 1
+    assert metrics[0].instruction_count >= 3
+    assert metrics[0].opcode_counts["PRINT"] == 1
+
+
+def test_runtime_tooling_cache_uses_source_hash_and_returns_fresh_chunks() -> None:
+    source = 'print("hi");'
+    cache = BytecodeCache()
+    build_calls = {"count": 0}
+
+    def build():
+        build_calls["count"] += 1
+        return compile_checked_chunk(source)
+
+    source_hash = sha256(source.encode("utf-8")).hexdigest()
+    first = cache.get_or_build(source_hash=source_hash, compiler_version="v1", build=build)
+    first.constants.append(SemeString("mutated"))
+    second = cache.get_or_build(source_hash=source_hash, compiler_version="v1", build=build)
+
+    assert build_calls["count"] == 1
+    assert second.constants == [SemeString("hi")]
+    assert len(first.constants) == 2

--- a/tests/unit/test_source_mapping.py
+++ b/tests/unit/test_source_mapping.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from seme.bytecode import Chunk, SourceSpan
+from seme.source_mapping import DEFAULT_SOURCE_SPAN, source_span_for_incomplete_chunk, source_span_for_offset
+
+
+def test_source_span_for_offset_returns_first_and_last_known_spans() -> None:
+    chunk = Chunk()
+    chunk.source_map.extend(
+        [
+            SourceSpan(line=2, column=4),
+            SourceSpan(line=3, column=8),
+        ]
+    )
+
+    assert source_span_for_offset(chunk, 0) == SourceSpan(line=2, column=4)
+    assert source_span_for_offset(chunk, 99) == SourceSpan(line=3, column=8)
+
+
+def test_source_span_for_offset_uses_default_for_empty_chunks() -> None:
+    chunk = Chunk()
+
+    assert source_span_for_offset(chunk, 0) == DEFAULT_SOURCE_SPAN
+
+
+def test_source_span_for_incomplete_chunk_falls_back_to_safe_resolution() -> None:
+    chunk = Chunk()
+    chunk.source_map.extend([SourceSpan(line=7, column=11)])
+
+    assert source_span_for_incomplete_chunk(chunk, 3) == SourceSpan(line=7, column=11)

--- a/tests/unit/test_vm.py
+++ b/tests/unit/test_vm.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from seme.compiler import compile_program
+from seme.lexer import lex
+from seme.parser import parse
+from seme.typechecker import check_types
+from seme.vm import execute_chunk
+
+
+def execute_source(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    chunk = compile_program(program)
+    return execute_chunk(chunk)
+
+
+def test_vm_executes_basic_program_and_prints_output() -> None:
+    stdout_lines, diags = execute_source("let x = 1 + 2 * 3; print(x); print(true);")
+
+    assert diags == []
+    assert stdout_lines == ["7", "true"]
+
+
+def test_vm_executes_control_flow_program() -> None:
+    source = """
+let sum = 0;
+for (let i = 0; i < 3; i = i + 1) {
+  if (i < 2) {
+    sum = sum + i;
+  }
+}
+print(sum);
+""".strip()
+    stdout_lines, diags = execute_source(source)
+
+    assert diags == []
+    assert stdout_lines == ["1"]
+
+
+def test_vm_maps_divide_by_zero_to_runtime_001() -> None:
+    stdout_lines, diags = execute_source("print(1); let x = 10 / 0; print(x);")
+
+    assert stdout_lines == ["1"]
+    assert len(diags) == 1
+    assert diags[0].code == "RUNTIME-001"
+    assert "division or modulo by zero" in diags[0].message
+
+
+def test_vm_maps_uninitialized_read_to_runtime_001() -> None:
+    stdout_lines, diags = execute_source("let x: int; print(x);")
+
+    assert stdout_lines == []
+    assert len(diags) == 1
+    assert diags[0].code == "RUNTIME-001"
+    assert "uninitialized" in diags[0].message
+
+
+def test_vm_short_circuits_logical_and_and_or() -> None:
+    source = """
+print(false && (1 / 0 == 0));
+print(true || (1 / 0 == 0));
+""".strip()
+    stdout_lines, diags = execute_source(source)
+
+    assert diags == []
+    assert stdout_lines == ["false", "true"]
+
+
+def test_vm_runtime_fault_reports_original_source_location() -> None:
+    source = """
+print(1);
+let x = 10 / 0;
+print(x);
+""".strip()
+    stdout_lines, diags = execute_source(source)
+
+    assert stdout_lines == ["1"]
+    assert [(d.code, d.line, d.column) for d in diags] == [
+        ("RUNTIME-001", 2, 12),
+    ]

--- a/tests/unit/test_vm.py
+++ b/tests/unit/test_vm.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from seme.compiler import compile_program
 from seme.lexer import lex
 from seme.parser import parse
+from seme.runtime import SemeBool, SemeInt
 from seme.typechecker import check_types
-from seme.vm import execute_chunk
+from seme.vm import VirtualMachine, execute_chunk
 
 
 def execute_source(source: str):
@@ -16,6 +17,16 @@ def execute_source(source: str):
     assert type_diags == []
     chunk = compile_program(program)
     return execute_chunk(chunk)
+
+
+def compile_checked_chunk(source: str):
+    tokens, lex_diags = lex(source)
+    assert lex_diags == []
+    program, parse_diags = parse(tokens)
+    assert parse_diags == []
+    type_diags = check_types(program)
+    assert type_diags == []
+    return compile_program(program)
 
 
 def test_vm_executes_basic_program_and_prints_output() -> None:
@@ -82,3 +93,14 @@ print(x);
     assert [(d.code, d.line, d.column) for d in diags] == [
         ("RUNTIME-001", 2, 12),
     ]
+
+
+def test_vm_keeps_runtime_value_objects_in_local_slots() -> None:
+    chunk = compile_checked_chunk("let x = 1 + 2; let ok = x == 3;")
+    vm = VirtualMachine(chunk)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == []
+    assert diags == []
+    assert vm.locals[:2] == [SemeInt(3), SemeBool(True)]

--- a/tests/unit/test_vm.py
+++ b/tests/unit/test_vm.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from seme.compiler import compile_program
+from seme.bytecode import Chunk, Instruction, OpCode, SourceSpan
 from seme.lexer import lex
 from seme.parser import parse
-from seme.runtime import SemeBool, SemeInt
+from seme.runtime import HeapRef, SemeBool, SemeInt
 from seme.typechecker import check_types
-from seme.vm import VirtualMachine, execute_chunk
+from seme.vm import Frame, VirtualMachine, execute_chunk
+from seme.vm_metrics import VMMetrics
+from seme.vm_trace import TracePhase
 
 
 def execute_source(source: str):
@@ -95,7 +98,7 @@ print(x);
     ]
 
 
-def test_vm_keeps_runtime_value_objects_in_local_slots() -> None:
+def test_vm_keeps_runtime_value_objects_in_global_storage_for_top_level_bindings() -> None:
     chunk = compile_checked_chunk("let x = 1 + 2; let ok = x == 3;")
     vm = VirtualMachine(chunk)
 
@@ -103,4 +106,117 @@ def test_vm_keeps_runtime_value_objects_in_local_slots() -> None:
 
     assert stdout_lines == []
     assert diags == []
-    assert vm.locals[:2] == [SemeInt(3), SemeBool(True)]
+    assert vm.runtime.globals == {"x": SemeInt(3), "ok": SemeBool(True)}
+    assert vm.locals == []
+
+
+def test_vm_bootstraps_with_a_single_current_frame() -> None:
+    chunk = compile_checked_chunk("let x = 1;")
+    vm = VirtualMachine(chunk)
+
+    assert len(vm.runtime.frames) == 1
+    assert isinstance(vm.runtime.current_frame, Frame)
+    assert vm.locals is vm.runtime.current_frame.locals
+
+
+def test_vm_stores_top_level_bindings_in_global_storage() -> None:
+    chunk = compile_checked_chunk("let x = 1 + 2; let ok = x == 3;")
+    vm = VirtualMachine(chunk)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == []
+    assert diags == []
+    assert vm.runtime.globals == {"x": SemeInt(3), "ok": SemeBool(True)}
+    assert vm.locals == []
+
+
+def test_vm_exposes_gc_root_values_for_stack_frames_globals_and_constants() -> None:
+    chunk = compile_checked_chunk('let msg = "hi"; print(msg);')
+    vm = VirtualMachine(chunk)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == ["hi"]
+    assert diags == []
+    assert any(isinstance(value, HeapRef) for value in vm.gc_root_values())
+    assert vm.runtime.heap.live_object_ids(vm.gc_root_values()) == {1}
+
+
+def test_vm_keeps_nested_block_shadowing_frame_local_over_global() -> None:
+    stdout_lines, diags = execute_source("let x = 1; { let x = 2; print(x); } print(x);")
+
+    assert diags == []
+    assert stdout_lines == ["2", "1"]
+
+
+def test_vm_refuses_to_execute_invalid_bytecode_chunks() -> None:
+    chunk = Chunk()
+    chunk.instructions.append(Instruction(opcode=OpCode.RETURN))
+
+    stdout_lines, diags = execute_chunk(chunk)
+
+    assert stdout_lines == []
+    assert [(d.code, d.message, d.line, d.column) for d in diags] == [
+        (
+            "BYTECODE-001",
+            "bytecode chunk instructions and source map lengths must match",
+            1,
+            1,
+        )
+    ]
+
+
+def test_vm_trace_hook_emits_before_and_after_events_without_changing_output() -> None:
+    chunk = compile_checked_chunk("print(1);")
+    events = []
+    vm = VirtualMachine(chunk, trace_hook=events.append)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == ["1"]
+    assert diags == []
+    assert len(events) == 6
+    assert [event.phase for event in events] == [
+        TracePhase.BEFORE,
+        TracePhase.AFTER,
+        TracePhase.BEFORE,
+        TracePhase.AFTER,
+        TracePhase.BEFORE,
+        TracePhase.AFTER,
+    ]
+    assert events[0].offset == 0
+    assert events[0].span.line == 1
+    assert events[0].span.column == 7
+    assert events[0].stack_depth == 0
+    assert events[-1].instruction.opcode is OpCode.RETURN
+
+
+def test_vm_trace_hook_emits_error_events_for_runtime_faults() -> None:
+    chunk = compile_checked_chunk("let x: int; print(x);")
+    events = []
+    vm = VirtualMachine(chunk, trace_hook=events.append)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == []
+    assert [(d.code, d.line, d.column) for d in diags] == [("RUNTIME-001", 1, 19)]
+    assert any(event.phase is TracePhase.ERROR for event in events)
+
+
+def test_vm_profiling_hook_emits_summary_without_changing_output() -> None:
+    chunk = compile_checked_chunk("print(1);")
+    summaries: list[VMMetrics] = []
+    vm = VirtualMachine(chunk, profiling_hook=summaries.append)
+
+    stdout_lines, diags = vm.execute()
+
+    assert stdout_lines == ["1"]
+    assert diags == []
+    assert len(summaries) == 1
+    metrics = summaries[0]
+    assert metrics.instruction_count == 3
+    assert metrics.opcode_counts == {"LOAD_CONST": 1, "PRINT": 1, "RETURN": 1}
+    assert metrics.max_stack_depth == 1
+    assert metrics.max_frame_depth == 1
+    assert metrics.wall_time_ns >= 0

--- a/tests/unit/test_vm_parity.py
+++ b/tests/unit/test_vm_parity.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from seme.pipeline import run_execute
+
+
+RUN_CASES = json.loads(
+    (Path(__file__).parents[1] / "fixtures" / "run_cases.json").read_text(encoding="utf-8")
+)
+
+
+@pytest.mark.parametrize("case", RUN_CASES, ids=[case["name"] for case in RUN_CASES])
+def test_vm_backend_matches_existing_run_conformance(case: dict) -> None:
+    stdout, diagnostics = run_execute(case["source"], backend="vm")
+
+    expected_stdout = case.get("expected_stdout", "")
+    expected_diagnostics = [
+        (
+            diag["code"],
+            diag["message"],
+            diag["line"],
+            diag["column"],
+        )
+        for diag in case.get("expected_diagnostics", [])
+    ]
+
+    assert stdout == expected_stdout
+    assert [
+        (diag.code, diag.message, diag.line, diag.column)
+        for diag in diagnostics
+    ] == expected_diagnostics
+
+
+@pytest.mark.parametrize("case", RUN_CASES, ids=[case["name"] for case in RUN_CASES])
+def test_vm_and_interpreter_backends_match_on_run_cases(case: dict) -> None:
+    vm_stdout, vm_diags = run_execute(case["source"], backend="vm")
+    interp_stdout, interp_diags = run_execute(case["source"], backend="interpreter")
+
+    assert vm_stdout == interp_stdout
+    assert [
+        (diag.code, diag.message, diag.line, diag.column)
+        for diag in vm_diags
+    ] == [
+        (diag.code, diag.message, diag.line, diag.column)
+        for diag in interp_diags
+    ]


### PR DESCRIPTION
Implements the runtime separation track and the bytecode tooling roadmap: frame/global/runtime-owned values, VM-backed REPL, validator/disassembler/debug CLI, tracing and profiling hooks, serialization/cache, source mapping, and peephole optimization. Tests: pytest (165 passed).